### PR TITLE
Prevent Icebreaker from pairing the same users in consecutive cycles

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -278,6 +278,10 @@
                             "value": "[variables('cosmosDbName')]"
                         },
                         {
+                            "name": "CosmosCollectionPairs",
+                            "value": "PairsHistory"
+                        },
+                        {
                             "name": "CosmosCollectionTeams",
                             "value": "TeamsInstalled"
                         },

--- a/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
+++ b/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
@@ -17,6 +17,7 @@ namespace Icebreaker.Helpers
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Client;
     using Microsoft.Azure.Documents.Linq;
+    using Microsoft.Bot.Schema;
 
     /// <summary>
     /// Data provider routines
@@ -31,6 +32,7 @@ namespace Icebreaker.Helpers
         private readonly ISecretsHelper secretsHelper;
         private DocumentClient documentClient;
         private Database database;
+        private DocumentCollection pairsCollection;
         private DocumentCollection teamsCollection;
         private DocumentCollection usersCollection;
 
@@ -65,6 +67,57 @@ namespace Icebreaker.Helpers
                 var documentUri = UriFactory.CreateDocumentUri(this.database.Id, this.teamsCollection.Id, team.Id);
                 var response = await this.documentClient.DeleteDocumentAsync(documentUri, new RequestOptions { PartitionKey = new PartitionKey(team.Id) });
             }
+        }
+
+        /// <summary>
+        /// Get a list of past pairings
+        /// </summary>
+        /// <returns>List of past pairings.</returns>
+        public async Task<IList<PairInfo>> GetPairHistoryAsync()
+        {
+            await this.EnsureInitializedAsync();
+
+            var pairHistory = new List<PairInfo>();
+
+            try
+            {
+                using (var lookupQuery = this.documentClient
+                    .CreateDocumentQuery<PairInfo>(this.pairsCollection.SelfLink, new FeedOptions { EnableCrossPartitionQuery = true })
+                    .AsDocumentQuery())
+                {
+                    while (lookupQuery.HasMoreResults)
+                    {
+                        var response = await lookupQuery.ExecuteNextAsync<PairInfo>();
+                        pairHistory.AddRange(response);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                this.telemetryClient.TrackException(ex.InnerException);
+            }
+
+            return pairHistory;
+        }
+
+        /// <summary>
+        /// Record a pairing that was made
+        /// </summary>
+        /// <param name="pair">A pairing.</param>
+        /// <param name="lastIteration">Value that indicates the iteration cycle when the pairing happened.</param>
+        /// <returns>Tracking task</returns>
+        public async Task AddPairAsync(Tuple<string, string> pair, int lastIteration)
+        {
+            await this.EnsureInitializedAsync();
+
+            var pairInfo = new PairInfo
+            {
+                User1Id = pair.Item1,
+                User2Id = pair.Item2,
+                Iteration = lastIteration,
+            };
+
+            var response = await this.documentClient.UpsertDocumentAsync(this.pairsCollection.SelfLink, pairInfo);
         }
 
         /// <summary>
@@ -220,6 +273,7 @@ namespace Icebreaker.Helpers
 
             var endpointUrl = CloudConfigurationManager.GetSetting("CosmosDBEndpointUrl");
             var databaseName = CloudConfigurationManager.GetSetting("CosmosDBDatabaseName");
+            var pairsCollectionName = CloudConfigurationManager.GetSetting("CosmosCollectionPairs");
             var teamsCollectionName = CloudConfigurationManager.GetSetting("CosmosCollectionTeams");
             var usersCollectionName = CloudConfigurationManager.GetSetting("CosmosCollectionUsers");
 
@@ -247,6 +301,14 @@ namespace Icebreaker.Helpers
                     throw;
                 }
             }
+
+            // Get a reference to the Pairs collection, creating it if needed
+            var pairCollectionDefinition = new DocumentCollection
+            {
+                Id = pairsCollectionName,
+            };
+            pairCollectionDefinition.PartitionKey.Paths.Add("/id");
+            this.pairsCollection = await this.documentClient.CreateDocumentCollectionIfNotExistsAsync(this.database.SelfLink, pairCollectionDefinition, useSharedOffer ? null : requestOptions);
 
             // Get a reference to the Teams collection, creating it if needed
             var teamsCollectionDefinition = new DocumentCollection

--- a/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
+++ b/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
@@ -104,9 +104,9 @@ namespace Icebreaker.Helpers
         /// Record a pairing that was made
         /// </summary>
         /// <param name="pair">A pairing.</param>
-        /// <param name="lastIteration">Value that indicates the iteration cycle when the pairing happened.</param>
+        /// <param name="iteration">Value that indicates the iteration cycle when the pairing happened.</param>
         /// <returns>Tracking task</returns>
-        public async Task AddPairAsync(Tuple<string, string> pair, int lastIteration)
+        public async Task AddPairAsync(Tuple<string, string> pair, int iteration)
         {
             await this.EnsureInitializedAsync();
 
@@ -114,10 +114,10 @@ namespace Icebreaker.Helpers
             {
                 User1Id = pair.Item1,
                 User2Id = pair.Item2,
-                Iteration = lastIteration,
+                Iteration = iteration,
             };
 
-            var response = await this.documentClient.UpsertDocumentAsync(this.pairsCollection.SelfLink, pairInfo);
+            var response = await this.documentClient.CreateDocumentAsync(this.pairsCollection.SelfLink, pairInfo);
         }
 
         /// <summary>

--- a/Source/Icebreaker/Helpers/PairInfo.cs
+++ b/Source/Icebreaker/Helpers/PairInfo.cs
@@ -1,0 +1,35 @@
+﻿//----------------------------------------------------------------------------------------------
+// <copyright file="PairInfo.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+//----------------------------------------------------------------------------------------------
+
+namespace Icebreaker.Helpers
+{
+    using Microsoft.Azure.Documents;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Represents a pairing that occurred
+    /// </summary>
+    public class PairInfo : Document
+    {
+        /// <summary>
+        /// Gets or sets the ID of the first user of the match
+        /// </summary>
+        [JsonProperty("user1Id")]
+        public string User1Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the second user of the match
+        /// </summary>
+        [JsonProperty("user2Id")]
+        public string User2Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the match iteration cycle that this match occured in
+        /// </summary>
+        [JsonProperty("iteration")]
+        public int Iteration { get; set; }
+    }
+}

--- a/Source/Icebreaker/Icebreaker.csproj
+++ b/Source/Icebreaker/Icebreaker.csproj
@@ -343,6 +343,7 @@
     <Compile Include="Helpers\AdaptiveCards\WelcomeTeamAdaptiveCard.cs" />
     <Compile Include="Helpers\ConversationHelper.cs" />
     <Compile Include="Helpers\IcebreakerBotDataProvider.cs" />
+    <Compile Include="Helpers\PairInfo.cs" />
     <Compile Include="Helpers\TeamInstallInfo.cs" />
     <Compile Include="Helpers\UserInfo.cs" />
     <Compile Include="IcebreakerModule.cs" />

--- a/Source/Icebreaker/Interfaces/IBotDataProvider.cs
+++ b/Source/Icebreaker/Interfaces/IBotDataProvider.cs
@@ -62,8 +62,8 @@ namespace Icebreaker.Interfaces
         /// Record a pairing that was made
         /// </summary>
         /// <param name="pair">A pairing.</param>
-        /// <param name="lastIteration">Value that indicates the iteration cycle when the pairing happened.</param>
+        /// <param name="iteration">Value that indicates the iteration cycle when the pairing happened.</param>
         /// <returns>Tracking task</returns>
-        Task AddPairAsync(Tuple<string, string> pair, int lastIteration);
+        Task AddPairAsync(Tuple<string, string> pair, int iteration);
     }
 }

--- a/Source/Icebreaker/Interfaces/IBotDataProvider.cs
+++ b/Source/Icebreaker/Interfaces/IBotDataProvider.cs
@@ -4,9 +4,11 @@
 
 namespace Icebreaker.Interfaces
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Icebreaker.Helpers;
+    using Microsoft.Bot.Schema;
 
     /// <summary>
     /// Data provider routines
@@ -49,5 +51,19 @@ namespace Icebreaker.Interfaces
         /// <param name="serviceUrl">User service URL</param>
         /// <returns>Tracking task</returns>
         Task SetUserInfoAsync(string tenantId, string userId, bool optedIn, string serviceUrl);
+
+        /// <summary>
+        /// Get a list of past pairings
+        /// </summary>
+        /// <returns>List of past pairings.</returns>
+        Task<IList<PairInfo>> GetPairHistoryAsync();
+
+        /// <summary>
+        /// Record a pairing that was made
+        /// </summary>
+        /// <param name="pair">A pairing.</param>
+        /// <param name="lastIteration">Value that indicates the iteration cycle when the pairing happened.</param>
+        /// <returns>Tracking task</returns>
+        Task AddPairAsync(Tuple<string, string> pair, int lastIteration);
     }
 }

--- a/Source/Icebreaker/Services/MatchingService.cs
+++ b/Source/Icebreaker/Services/MatchingService.cs
@@ -92,9 +92,6 @@ namespace Icebreaker.Services
                 var dummyPair = new Tuple<string, string>(null, null);
                 await this.dataProvider.AddPairAsync(dummyPair, lastIteration);
 
-                // debug message
-                await this.dataProvider.AddPairAsync(dummyPair, pastPairs.Count - 1000);
-
                 foreach (var team in teams)
                 {
                     this.telemetryClient.TrackTrace($"Pairing members of team {team.Id}");

--- a/Source/Icebreaker/Web.config
+++ b/Source/Icebreaker/Web.config
@@ -11,6 +11,7 @@
 		<add key="CosmosDBEndpointUrl" value="" />
 		<add key="CosmosDBKey" value="" />
 		<add key="CosmosDBDatabaseName" value="" />
+		<add key="CosmosCollectionPairs" value="PairsHistory" />
 		<add key="CosmosCollectionTeams" value="TeamsInstalled" />
 		<add key="CosmosCollectionUsers" value="UsersOptInStatus" />
 		<add key="MaxPairUpsPerTeam" value="5000" />

--- a/Wiki/Data-stores.md
+++ b/Wiki/Data-stores.md
@@ -6,6 +6,16 @@ All these resources are created in your Azure subscription. None are hosted dire
 
 ## Azure Cosmos DB Account
 
+### Pairs Collection
+
+The Pairs Collection stores the metadata needed to determine pairings that should be avoided to prevent frequent repetition.
+
+| Value         | Description
+| ---           | ---
+| User1Id       | The first user of the pair's ID
+| User2Id       | The second user of the pair's ID
+| Iteration     | The ID of the iteration that this match occured in
+
 ### Teams Collection
 
 The Teams Collection stores the metadata needed to determine which teams are being tracked for pairups by the bot and the metadata needed to fetch the roster and notify the users for each team.


### PR DESCRIPTION
**Description**
This is the implementation and unit tests for preventing Icebreaker from pairing the same users back to back within two cycles. This involves creating a container called `PairsHistory` which stores information about pairings and the cycle under which they occur. Each cycle, information about past pairs from previous cycle(s) are used to prevent those pairs from being made again.

**User facing changes**
A pair of users will not be matched more than once within two consecutive matching cycles with respect to the Icebreaker application (regardless of the number of teams the pair is in).

**Test Scenarios**
1. 2 Users on 1 Team
_Before_: The 2 users will be matched on cycles 1, 2, 3...
_After_: The 2 users will be matched on cycles 1, 3, 5...

2. The same 2 Users on 2 Teams
_Before_: The 2 users will be matched on cycles 1, 2, 3... on both teams
_After_: The 2 users will be matched on cycles 1, 3, 5... on one of those teams

**Follow-up Work**
There are plans to adjust the timeframe under which a pair of users will not be matched more than once based on user preference. With this in mind, all past pairings are kept in the database instead of only the most recent cycle's pairings.