### PR TITLE
Allow users to set up profiles that are shared with future matches

### DIFF
--- a/Source/Icebreaker/Bot/IcebreakerBot.cs
+++ b/Source/Icebreaker/Bot/IcebreakerBot.cs
@@ -145,16 +145,17 @@ namespace Icebreaker.Bot
                         await this.SaveAddedToTeam(message.ServiceUrl, teamId, teamsChannelData.Tenant.Id, personThatAddedBot);
                         await this.WelcomeTeam(turnContext, personThatAddedBot, cancellationToken);
 
-                        // var watch = new System.Diagnostics.Stopwatch();
-                        // watch.Start();
+                        var watch = System.Diagnostics.Stopwatch.StartNew();
+
                         var users = await ((BotFrameworkAdapter)turnContext.Adapter).GetConversationMembersAsync(turnContext, cancellationToken);
                         foreach (var user in users)
                         {
                             await this.WelcomeUser(turnContext, user.Id, teamsChannelData.Tenant.Id, teamsChannelData.Team.Id, cancellationToken);
                         }
 
-                        // watch.Stop();
-                        // this.telemetryClient.TrackTrace($"Time to notify all users: {watch.ElapsedMilliseconds} ms");
+                        watch.Stop();
+                        this.telemetryClient.TrackTrace($"Execution Time: {watch.ElapsedMilliseconds} ms");
+
                     }
                     else
                     {

--- a/Source/Icebreaker/Bot/IcebreakerBot.cs
+++ b/Source/Icebreaker/Bot/IcebreakerBot.cs
@@ -155,7 +155,6 @@ namespace Icebreaker.Bot
 
                         watch.Stop();
                         this.telemetryClient.TrackTrace($"Execution Time: {watch.ElapsedMilliseconds} ms");
-
                     }
                     else
                     {

--- a/Source/Icebreaker/Bot/IcebreakerBot.cs
+++ b/Source/Icebreaker/Bot/IcebreakerBot.cs
@@ -344,10 +344,10 @@ namespace Icebreaker.Bot
             var cardPayload = JToken.Parse(activity.Value.ToString());
             var cardAction = cardPayload["action"].Value<string>().ToLowerInvariant();
             var userInfo = await this.dataProvider.GetUserInfoAsync(activity.From.AadObjectId);
+
             switch (cardAction)
             {
                 case "update":
-
                     var profile = cardPayload["profile"].Value<string>();
                     await this.dataProvider.SetUserInfoAsync(userInfo.TenantId, userInfo.UserId, userInfo.OptedIn, userInfo.ServiceUrl, profile);
 
@@ -357,12 +357,13 @@ namespace Icebreaker.Bot
                     {
                         new HeroCard()
                         {
-                            Text = "Your profile has been updated!"
+                            Text = Resources.UpdateProfileConfirmation
                         }.ToAttachment(),
                     };
 
                     await turnContext.SendActivityAsync(reply, cancellationToken).ConfigureAwait(false);
                     break;
+
                 default:
                     this.telemetryClient.TrackTrace($"Unknown action taken: {cardAction}");
                     break;

--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
@@ -29,34 +29,37 @@ namespace Icebreaker.Helpers.AdaptiveCards
         /// Creates the pairup notification card.
         /// </summary>
         /// <param name="teamName">The team name.</param>
-        /// <param name="sender">The user who will be sending this card.</param>
         /// <param name="recipient">The user who will be receiving this card.</param>
+        /// <param name="sender">The user who will be sending this card.</param>
+        /// <param name="senderProfile">The profile of the sender.</param>
         /// <param name="botDisplayName">The bot display name.</param>
         /// <returns>Pairup notification card</returns>
-        public static Attachment GetCard(string teamName, TeamsChannelAccount sender, TeamsChannelAccount recipient, string botDisplayName)
+        public static Attachment GetCard(string teamName, TeamsChannelAccount recipient, TeamsChannelAccount sender, string senderProfile, string botDisplayName)
         {
             // Guest users may not have their given name specified in AAD, so fall back to the full name if needed
-            var senderGivenName = string.IsNullOrEmpty(sender.GivenName) ? sender.Name : sender.GivenName;
             var recipientGivenName = string.IsNullOrEmpty(recipient.GivenName) ? recipient.Name : recipient.GivenName;
+            var senderGivenName = string.IsNullOrEmpty(sender.GivenName) ? sender.Name : sender.GivenName;
 
             // To start a chat with a guest user, use their external email, not the UPN
-            var recipientUpn = !IsGuestUser(recipient) ? recipient.UserPrincipalName : recipient.Email;
+            var senderUpn = !IsGuestUser(sender) ? sender.UserPrincipalName : sender.Email;
 
-            var meetingTitle = string.Format(Resources.MeetupTitle, senderGivenName, recipientGivenName);
+            var meetingTitle = string.Format(Resources.MeetupTitle, recipientGivenName, senderGivenName);
             var meetingContent = string.Format(Resources.MeetupContent, botDisplayName);
-            var meetingLink = "https://teams.microsoft.com/l/meeting/new?subject=" + Uri.EscapeDataString(meetingTitle) + "&attendees=" + recipientUpn + "&content=" + Uri.EscapeDataString(meetingContent);
+            var meetingLink = "https://teams.microsoft.com/l/meeting/new?subject=" + Uri.EscapeDataString(meetingTitle) + "&attendees=" + senderUpn + "&content=" + Uri.EscapeDataString(meetingContent);
 
             var cardData = new
             {
                 matchUpCardTitleContent = Resources.MatchUpCardTitleContent,
-                matchUpCardMatchedText = string.Format(Resources.MatchUpCardMatchedText, recipient.Name),
-                matchUpCardContentPart1 = string.Format(Resources.MatchUpCardContentPart1, botDisplayName, teamName, recipient.Name),
+                matchUpCardMatchedText = string.Format(Resources.MatchUpCardMatchedText, sender.Name),
+                matchUpCardContentPart1 = string.IsNullOrEmpty(senderProfile) ?
+                    string.Format(Resources.MatchUpCardContentPart1, botDisplayName, teamName, sender.Name) :
+                    string.Format(Resources.MatchUpCardContentPart1b, botDisplayName, teamName, sender.Name, senderProfile),
                 matchUpCardContentPart2 = Resources.MatchUpCardContentPart2,
-                chatWithMatchButtonText = string.Format(Resources.ChatWithMatchButtonText, recipientGivenName),
+                chatWithMatchButtonText = string.Format(Resources.ChatWithMatchButtonText, senderGivenName),
                 chatWithMessageGreeting = Resources.ChatWithMessageGreeting,
                 pauseMatchesButtonText = Resources.PausePairingsButtonText,
                 proposeMeetupButtonText = Resources.ProposeMeetupButtonText,
-                personUpn = recipientUpn,
+                personUpn = senderUpn,
                 meetingLink,
             };
 

--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
@@ -58,7 +58,9 @@ namespace Icebreaker.Helpers.AdaptiveCards
                 chatWithMatchButtonText = string.Format(Resources.ChatWithMatchButtonText, senderGivenName),
                 chatWithMessageGreeting = Resources.ChatWithMessageGreeting,
                 pauseMatchesButtonText = Resources.PausePairingsButtonText,
+                profilePlaceholderText = Resources.ProfilePlaceholderText,
                 proposeMeetupButtonText = Resources.ProposeMeetupButtonText,
+                updateProfileButtonText = Resources.UpdateProfileButtonText,
                 personUpn = senderUpn,
                 meetingLink,
             };

--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
@@ -66,6 +66,36 @@
           "text": "optout"
         }
       }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "Update profile",
+      "card": {
+          "type": "AdaptiveCard",
+          "body": [
+              {
+                  "type": "Container",
+                  "items": [
+                      {
+                          "type": "Input.Text",
+                          "id": "profile",
+                          "placeholder": "Share something about yourself with future matches!",
+                          "maxLength": 1000,
+                          "isMultiline": true
+                      }
+                  ]
+              }
+          ],
+          "actions": [
+              {
+                  "type": "Action.Submit",
+                  "title": "Save",
+                  "data": {
+                      "action": "update"
+                  }
+              }
+          ]
+      }
     }
   ],
   "version": "1.0"

--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
@@ -69,7 +69,7 @@
     },
     {
       "type": "Action.ShowCard",
-      "title": "Update profile",
+      "title": "${updateProfileButtonText}",
       "card": {
           "type": "AdaptiveCard",
           "body": [
@@ -79,7 +79,7 @@
                       {
                           "type": "Input.Text",
                           "id": "profile",
-                          "placeholder": "Share something about yourself with future matches!",
+                          "placeholder": "${profilePlaceholderText}",
                           "maxLength": 1000,
                           "isMultiline": true
                       }

--- a/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.cs
@@ -62,8 +62,10 @@ namespace Icebreaker.Helpers.AdaptiveCards
                 team = teamName,
                 welcomeCardImageUrl = $"https://{baseDomain}/Content/welcome-card-image.png",
                 pauseMatchesText = Resources.PausePairingsButtonText,
+                profilePlaceholderText = Resources.ProfilePlaceholderText,
                 tourUrl = $"https://teams.microsoft.com/l/task/{appId}?url={htmlUrl}&height=533px&width=600px&title={tourTitle}",
                 salutationText = Resources.SalutationTitleText,
+                setUpProfileButtonText = Resources.SetUpProfileButtonText,
                 tourButtonText = Resources.TakeATourButtonText
             };
 

--- a/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
@@ -58,6 +58,36 @@
           "text": "optout"
         }
       }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "Set up profile",
+      "card": {
+          "type": "AdaptiveCard",
+          "body": [
+              {
+                  "type": "Container",
+                  "items": [
+                      {
+                          "type": "Input.Text",
+                          "id": "profile",
+                          "placeholder": "Share something about yourself with future matches!",
+                          "maxLength": 1000,
+                          "isMultiline": true
+                      }
+                  ]
+              }
+          ],
+          "actions": [
+              {
+                  "type": "Action.Submit",
+                  "title": "Save",
+                  "data": {
+                      "action": "update"
+                  }
+              }
+          ]
+      }
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
@@ -61,7 +61,7 @@
     },
     {
       "type": "Action.ShowCard",
-      "title": "Set up profile",
+      "title": "${setUpProfileButtonText}",
       "card": {
           "type": "AdaptiveCard",
           "body": [
@@ -71,7 +71,7 @@
                       {
                           "type": "Input.Text",
                           "id": "profile",
-                          "placeholder": "Share something about yourself with future matches!",
+                          "placeholder": "${profilePlaceholderText}",
                           "maxLength": 1000,
                           "isMultiline": true
                       }

--- a/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
+++ b/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
@@ -242,14 +242,62 @@ namespace Icebreaker.Helpers
         }
 
         /// <summary>
+        /// Get the stored profiles of given users
+        /// </summary>
+        /// <returns>User's custom profiles</returns>
+        public async Task<Dictionary<string, string>> GetAllUsersProfileAsync()
+        {
+            await this.EnsureInitializedAsync();
+
+            try
+            {
+                var collectionLink = UriFactory.CreateDocumentCollectionUri(this.database.Id, this.usersCollection.Id);
+                var query = this.documentClient.CreateDocumentQuery<UserInfo>(
+                        collectionLink,
+#pragma warning disable SA1118 // Parameter must not span multiple lines
+                        new FeedOptions
+                        {
+                            EnableCrossPartitionQuery = true,
+
+                            // Fetch items in bulk according to DB engine capability
+                            MaxItemCount = -1,
+
+                            // Max partition to query at a time
+                            MaxDegreeOfParallelism = -1
+                        })
+#pragma warning restore SA1118 // Parameter must not span multiple lines
+                    .Select(u => new UserInfo { Id = u.Id, Profile = u.Profile })
+                    .AsDocumentQuery();
+                var usersProfileLookup = new Dictionary<string, string>();
+                while (query.HasMoreResults)
+                {
+                    // Note that ExecuteNextAsync can return many records in each call
+                    var responseBatch = await query.ExecuteNextAsync<UserInfo>();
+                    foreach (var userInfo in responseBatch)
+                    {
+                        usersProfileLookup.Add(userInfo.Id, userInfo.Profile);
+                    }
+                }
+
+                return usersProfileLookup;
+            }
+            catch (Exception ex)
+            {
+                this.telemetryClient.TrackException(ex.InnerException);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Set the user info for the given user
         /// </summary>
         /// <param name="tenantId">Tenant id</param>
         /// <param name="userId">User id</param>
         /// <param name="optedIn">User opt-in status</param>
         /// <param name="serviceUrl">User service URL</param>
+        /// <param name="profile">User profile</param>
         /// <returns>Tracking task</returns>
-        public async Task SetUserInfoAsync(string tenantId, string userId, bool optedIn, string serviceUrl)
+        public async Task SetUserInfoAsync(string tenantId, string userId, bool optedIn, string serviceUrl, string profile)
         {
             await this.EnsureInitializedAsync();
 
@@ -258,7 +306,8 @@ namespace Icebreaker.Helpers
                 TenantId = tenantId,
                 UserId = userId,
                 OptedIn = optedIn,
-                ServiceUrl = serviceUrl
+                ServiceUrl = serviceUrl,
+                Profile = profile,
             };
             await this.documentClient.UpsertDocumentAsync(this.usersCollection.SelfLink, userInfo);
         }

--- a/Source/Icebreaker/Helpers/UserInfo.cs
+++ b/Source/Icebreaker/Helpers/UserInfo.cs
@@ -49,5 +49,11 @@ namespace Icebreaker.Helpers
         /// </summary>
         [JsonProperty("recentPairups")]
         public List<UserInfo> RecentPairUps { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's profile
+        /// </summary>
+        [JsonProperty("profile")]
+        public string Profile { get; set; }
     }
 }

--- a/Source/Icebreaker/Interfaces/IBotDataProvider.cs
+++ b/Source/Icebreaker/Interfaces/IBotDataProvider.cs
@@ -28,6 +28,12 @@ namespace Icebreaker.Interfaces
         Task<Dictionary<string, bool>> GetAllUsersOptInStatusAsync();
 
         /// <summary>
+        /// Get the stored profiles of given users
+        /// </summary>
+        /// <returns>User's custom profiles</returns>
+        Task<Dictionary<string, string>> GetAllUsersProfileAsync();
+
+        /// <summary>
         /// Returns the team that the bot has been installed to
         /// </summary>
         /// <param name="teamId">The team id</param>
@@ -49,14 +55,22 @@ namespace Icebreaker.Interfaces
         /// <param name="userId">User id</param>
         /// <param name="optedIn">User opt-in status</param>
         /// <param name="serviceUrl">User service URL</param>
+        /// <param name="profile">User profile</param>
         /// <returns>Tracking task</returns>
-        Task SetUserInfoAsync(string tenantId, string userId, bool optedIn, string serviceUrl);
+        Task SetUserInfoAsync(string tenantId, string userId, bool optedIn, string serviceUrl, string profile);
 
         /// <summary>
         /// Get a list of past pairings
         /// </summary>
         /// <returns>List of past pairings.</returns>
         Task<IList<PairInfo>> GetPairHistoryAsync();
+
+        /// <summary>
+        /// Get the stored information about the given user
+        /// </summary>
+        /// <param name="userId">User id</param>
+        /// <returns>User information</returns>
+        Task<UserInfo> GetUserInfoAsync(string userId);
 
         /// <summary>
         /// Record a pairing that was made

--- a/Source/Icebreaker/Properties/Resources.Designer.cs
+++ b/Source/Icebreaker/Properties/Resources.Designer.cs
@@ -230,7 +230,16 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("PausePairingsButtonText", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Share something about yourself with future matches!.
+        /// </summary>
+        internal static string ProfilePlaceholderText {
+            get {
+                return ResourceManager.GetString("ProfilePlaceholderText", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Propose meetup.
         /// </summary>
@@ -257,7 +266,7 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("SalutationTitleText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Take a tour.
         /// </summary>
@@ -268,11 +277,38 @@ namespace Icebreaker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Set up profile.
+        /// </summary>
+        internal static string SetUpProfileButtonText {
+            get {
+                return ResourceManager.GetString("SetUpProfileButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to I&apos;m sorry, but I can&apos;t process the incoming message. You can take a tour, though, to learn more about my functionality..
         /// </summary>
         internal static string UnrecognizedInput {
             get {
                 return ResourceManager.GetString("UnrecognizedInput", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Update profile.
+        /// </summary>
+        internal static string UpdateProfileButtonText {
+            get {
+                return ResourceManager.GetString("UpdateProfileButtonText", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Your profile has been updated!
+        /// </summary>
+        internal static string UpdateProfileConfirmation {
+            get {
+                return ResourceManager.GetString("UpdateProfileConfirmation", resourceCulture);
             }
         }
         

--- a/Source/Icebreaker/Properties/Resources.Designer.cs
+++ b/Source/Icebreaker/Properties/Resources.Designer.cs
@@ -149,6 +149,15 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("MatchUpCardContentPart1", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hi there again, I&apos;m {0} in {1}. A bot that pairs you with a new coworker to meet each week. This week your match is {2}. Here is something they wanted to let you know about them: {3}..
+        /// </summary>
+        internal static string MatchUpCardContentPart1b {
+            get {
+                return ResourceManager.GetString("MatchUpCardContentPart1b", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to If you&apos;ve got the inclination, set something up. See, meeting people *is* easy!.

--- a/Source/Icebreaker/Properties/Resources.resx
+++ b/Source/Icebreaker/Properties/Resources.resx
@@ -157,6 +157,10 @@
     <value>Hi there again, I'm {0} in {1}. A bot that pairs you with a new coworker to meet each week. This week your match is {2}.</value>
     <comment>First part of the match up card main content</comment>
   </data>
+  <data name="MatchUpCardContentPart1b" xml:space="preserve">
+    <value>Hi there again, I'm {0} in {1}. A bot that pairs you with a new coworker to meet each week. This week your match is {2}. Here is something they wanted to let you know about them: {3}</value>
+    <comment>First part of the match up card main content for users that have a profile</comment>
+  </data>
   <data name="MatchUpCardContentPart2" xml:space="preserve">
     <value>If you've got the inclination, set something up. See, meeting people *is* easy!</value>
     <comment>Second part of the match up card main content</comment>

--- a/Source/Icebreaker/Properties/Resources.resx
+++ b/Source/Icebreaker/Properties/Resources.resx
@@ -193,6 +193,10 @@
     <value>Pause all matches</value>
     <comment>Button text to pause pairings</comment>
   </data>
+  <data name="ProfilePlaceholderText" xml:space="preserve">
+    <value>Share something about yourself with future matches!</value>
+    <comment>Placeholder for textbox when updating profile.</comment>
+  </data>
   <data name="ProposeMeetupButtonText" xml:space="preserve">
     <value>Propose meetup</value>
     <comment>Button text to propose the meetup with the match of the user</comment>
@@ -205,6 +209,10 @@
     <value>Hi there!</value>
     <comment>This is the text for the salutation in the adaptive cards when the bot is installed to a team and also when new users are added to the team</comment>
   </data>
+  <data name="SetUpProfileButtonText" xml:space="preserve">
+    <value>Set up Profile</value>
+    <comment>Button text to set up profile</comment>
+  </data>
   <data name="TakeATourButtonText" xml:space="preserve">
     <value>Take a tour</value>
     <comment>The text for the button which launches a tour when clicked</comment>
@@ -212,6 +220,14 @@
   <data name="UnrecognizedInput" xml:space="preserve">
     <value>I'm sorry, but I can't process the incoming message. You can take a tour, though, to learn more about my functionality.</value>
     <comment>The text for the unrecognized input scenario</comment>
+  </data>
+  <data name="UpdateProfileButtonText" xml:space="preserve">
+    <value>Update Profile</value>
+    <comment>Button text to update profile</comment>
+  </data>
+  <data name="UpdateProfileConfirmation" xml:space="preserve">
+    <value>Your profile has been updated!</value>
+    <comment>The confirmation reply that is sent when the user updates the profile</comment>
   </data>
   <data name="WelcomeTourTitle" xml:space="preserve">
     <value>Tour</value>

--- a/Source/Icebreaker/Services/MatchingService.cs
+++ b/Source/Icebreaker/Services/MatchingService.cs
@@ -108,14 +108,11 @@ namespace Icebreaker.Services
 
                             var user1AadId = this.GetChannelUserObjectId(pair.Item1);
                             var user2AadId = this.GetChannelUserObjectId(pair.Item2);
-                            var profile1 = dbMembersProfile.ContainsKey(user1AadId) ? dbMembersProfile[user1AadId] : null;
-                            var profile2 = dbMembersProfile.ContainsKey(user2AadId) ? dbMembersProfile[user2AadId] : null;
 
-                            var profiles = new Tuple<string, string>(profile1, profile2);
+                            var user1 = new Tuple<ChannelAccount, string>(pair.Item1, dbMembersProfile.ContainsKey(user1AadId) ? dbMembersProfile[user1AadId] : null);
+                            var user2 = new Tuple<ChannelAccount, string>(pair.Item2, dbMembersProfile.ContainsKey(user2AadId) ? dbMembersProfile[user2AadId] : null);
 
-                            // var profiles = new Tuple<string, string>("A", "B");
-
-                            usersNotifiedCount += await this.NotifyPairAsync(team, teamName, pair, profiles, default(CancellationToken));
+                            usersNotifiedCount += await this.NotifyPairAsync(team, teamName, user1, user2, default(CancellationToken));
                             pairsNotifiedCount++;
                         }
                     }
@@ -151,22 +148,22 @@ namespace Icebreaker.Services
         /// </summary>
         /// <param name="teamModel">DB team model info.</param>
         /// <param name="teamName">MS-Teams team name</param>
-        /// <param name="pair">The pairup</param>
-        /// <param name="profiles">The pairup's respective profiles</param>
+        /// <param name="user1">The pair's first user's ChannelAccount and profile</param>
+        /// <param name="user2">The pair's second user's ChannelAccount and profile</param>
         /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
         /// <returns>Number of users notified successfully</returns>
-        private async Task<int> NotifyPairAsync(TeamInstallInfo teamModel, string teamName, Tuple<ChannelAccount, ChannelAccount> pair, Tuple<string, string> profiles, CancellationToken cancellationToken)
+        private async Task<int> NotifyPairAsync(TeamInstallInfo teamModel, string teamName, Tuple<ChannelAccount, string> user1, Tuple<ChannelAccount, string> user2, CancellationToken cancellationToken)
         {
-            this.telemetryClient.TrackTrace($"Sending pairup notification to {pair.Item1.Id} and {pair.Item2.Id}");
+            this.telemetryClient.TrackTrace($"Sending pairup notification to {user1.Item1.Id} and {user2.Item1.Id}");
 
-            var teamsPerson1 = JObject.FromObject(pair.Item1).ToObject<TeamsChannelAccount>();
-            var teamsPerson2 = JObject.FromObject(pair.Item2).ToObject<TeamsChannelAccount>();
+            var teamsPerson1 = JObject.FromObject(user1.Item1).ToObject<TeamsChannelAccount>();
+            var teamsPerson2 = JObject.FromObject(user2.Item1).ToObject<TeamsChannelAccount>();
 
             // Fill in person2's info in the card for person1
-            var cardForPerson1 = PairUpNotificationAdaptiveCard.GetCard(teamName, teamsPerson1, teamsPerson2, profiles.Item2, this.botDisplayName);
+            var cardForPerson1 = PairUpNotificationAdaptiveCard.GetCard(teamName, teamsPerson1, teamsPerson2, user2.Item2, this.botDisplayName);
 
             // Fill in person1's info in the card for person2
-            var cardForPerson2 = PairUpNotificationAdaptiveCard.GetCard(teamName, teamsPerson2, teamsPerson1, profiles.Item1, this.botDisplayName);
+            var cardForPerson2 = PairUpNotificationAdaptiveCard.GetCard(teamName, teamsPerson2, teamsPerson1, user1.Item2, this.botDisplayName);
 
             // Send notifications and return the number that was successful
             var notifyResults = await Task.WhenAll(

--- a/Source/Icebreaker/Services/MatchingService.cs
+++ b/Source/Icebreaker/Services/MatchingService.cs
@@ -110,7 +110,7 @@ namespace Icebreaker.Services
                             var user2AadId = this.GetChannelUserObjectId(pair.Item2);
                             var profile1 = dbMembersProfile.ContainsKey(user1AadId) ? dbMembersProfile[user1AadId] : null;
                             var profile2 = dbMembersProfile.ContainsKey(user2AadId) ? dbMembersProfile[user2AadId] : null;
-                            
+
                             var profiles = new Tuple<string, string>(profile1, profile2);
 
                             // var profiles = new Tuple<string, string>("A", "B");


### PR DESCRIPTION
**Description**
This is the implementation for allowing users to set profiles for themselves. In this update, a welcome card is sent to each user individually (regardless of whether they join before or after Icebreaker is added). This welcome card includes a "Set up profile" button which can be used to configure their profile. Once saved, this profile will be shared with future matches in the match card. The match card also includes a "Update profile" button, which can be used to conveniently update their profile for future matches.

**User facing changes**
Users will always receive a personal welcome card from Icebreaker with an option to set up their profile. Match cards include an option to update their profile. Match cards share a user's profile with their match if it exists.

**Follow-up work**
Currently, users are not stored in the database until a user chooses to "Pause all matches" (users using Icebreaker may never be stored in the database). This can lead to issues when setting up a profile before the user is in the database. Another feature currently in development addresses this issue by storing all users that are part of a team with Icebreaker no matter what.

Tests can be configured that cover different lengths of profiles for users (represented as strings), the types of characters supported, etc.