### PR TITLE
Add feedback card after matches

### DIFF
--- a/Source/Icebreaker/Bot/IcebreakerBot.cs
+++ b/Source/Icebreaker/Bot/IcebreakerBot.cs
@@ -147,6 +147,17 @@ namespace Icebreaker.Bot
 
                         await this.SaveAddedToTeamAsync(serviceUrl, teamId, turnContext, personThatAddedBot);
                         await this.WelcomeTeam(turnContext, personThatAddedBot, cancellationToken);
+
+                        var watch = System.Diagnostics.Stopwatch.StartNew();
+
+                        var users = await ((BotFrameworkAdapter)turnContext.Adapter).GetConversationMembersAsync(turnContext, cancellationToken);
+                        foreach (var user in users)
+                        {
+                            await this.WelcomeUser(turnContext, user.Id, teamsChannelData.Tenant.Id, teamsChannelData.Team.Id, cancellationToken);
+                        }
+
+                        watch.Stop();
+                        this.telemetryClient.TrackTrace($"Execution Time: {watch.ElapsedMilliseconds} ms");
                     }
                     else
                     {
@@ -254,7 +265,7 @@ namespace Icebreaker.Bot
                 if (userInfo.CardToDelete != null)
                 {
                     await turnContext.DeleteActivityAsync(userInfo.CardToDelete, cancellationToken);
-                    await this.dataProvider.SetUserInfoAsync(userInfo.TenantId, senderAadId, userInfo.OptedIn, userInfo.ServiceUrl, null);
+                    await this.dataProvider.SetUserInfoAsync(userInfo.TenantId, senderAadId, userInfo.OptedIn, userInfo.ServiceUrl, userInfo.Profile, null);
                 }
 
                 // Adaptive card was submitted
@@ -265,8 +276,7 @@ namespace Icebreaker.Bot
                     await this.OnAdaptiveCardSubmitAsync(activity, turnContext, cancellationToken).ConfigureAwait(false);
                     return;
                 }
-
-                if (string.Equals(activity.Text, MatchingActions.OptOut, StringComparison.InvariantCultureIgnoreCase))
+                else if (string.Equals(activity.Text, MatchingActions.OptOut, StringComparison.InvariantCultureIgnoreCase))
                 {
                     // User opted out
                     this.telemetryClient.TrackTrace($"User {senderAadId} opted out");
@@ -369,7 +379,7 @@ namespace Icebreaker.Bot
             var response = await turnContext.SendActivityAsync(teamsViewCard, cancellationToken);
 
             // update card to delete
-            await this.dataProvider.SetUserInfoAsync(userInfo.TenantId, userInfo.Id, userInfo.OptedIn, userInfo.ServiceUrl, response.Id);
+            await this.dataProvider.SetUserInfoAsync(userInfo.TenantId, userInfo.Id, userInfo.OptedIn, userInfo.ServiceUrl, userInfo.Profile, response.Id);
         }
 
         /// <summary>
@@ -382,12 +392,12 @@ namespace Icebreaker.Bot
         private async Task OnAdaptiveCardSubmitAsync(Activity activity, ITurnContext turnContext, CancellationToken cancellationToken)
         {
             var cardPayload = JToken.Parse(activity.Value.ToString());
-            var cardType = cardPayload["ActionType"].Value<string>().ToLowerInvariant();
+            var cardActionType = cardPayload["ActionType"].Value<string>().ToLowerInvariant();
             var teamId = activity.Conversation.Id;
             var userId = activity.From.AadObjectId;
             var userInfo = await this.dataProvider.GetUserInfoAsync(userId);
 
-            switch (cardType)
+            switch (cardActionType)
             {
                 // updated pause preferences
                 case "saveopt":
@@ -416,7 +426,7 @@ namespace Icebreaker.Bot
                         }
                     }
 
-                    await this.dataProvider.SetUserInfoAsync(userInfo.TenantId, userId, optedIn, userInfo.ServiceUrl, userInfo.CardToDelete);
+                    await this.dataProvider.SetUserInfoAsync(userInfo.TenantId, userId, optedIn, userInfo.ServiceUrl, userInfo.Profile, userInfo.CardToDelete);
 
                     // send active teams
                     AdaptiveCard activeTeamsCard = new AdaptiveCard("1.2")
@@ -485,6 +495,27 @@ namespace Icebreaker.Bot
 
                     // send view teams card
                     await this.SendViewTeamsCardAsync(turnContext, userInfo, cancellationToken);
+                    break;
+
+                case "update":
+                    var profile = cardPayload["profile"].Value<string>();
+                    await this.dataProvider.SetUserInfoAsync(userInfo.TenantId, userInfo.UserId, userInfo.OptedIn, userInfo.ServiceUrl, profile, userInfo.CardToDelete);
+
+                    // Confirmation message
+                    var reply = activity.CreateReply();
+                    reply.Attachments = new List<Attachment>
+                    {
+                        new HeroCard()
+                        {
+                            Text = Resources.UpdateProfileConfirmation
+                        }.ToAttachment(),
+                    };
+
+                    await turnContext.SendActivityAsync(reply, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                default:
+                    this.telemetryClient.TrackTrace($"Unknown action taken: {cardActionType}");
                     break;
             }
         }
@@ -562,18 +593,6 @@ namespace Icebreaker.Bot
             var teamName = turnContext.Activity.TeamsGetTeamInfo().Name;
             var welcomeTeamMessageCard = WelcomeTeamAdaptiveCard.GetCard(teamName, botInstaller);
             await this.NotifyTeamAsync(turnContext, MessageFactory.Attachment(welcomeTeamMessageCard), teamId, cancellationToken);
-
-            // welcome users on team
-            var teamInfo = await this.GetInstalledTeam(teamId);
-            var botAdapter = (BotFrameworkAdapter)turnContext.Adapter;
-            var tenantId = turnContext.Activity.GetChannelData<TeamsChannelData>().Tenant.Id;
-            var members = await this.conversationHelper.GetTeamMembers(botAdapter, teamInfo);
-
-            foreach (var member in members)
-            {
-                var userId = this.GetChannelUserObjectId(member);
-                await this.WelcomeUser(turnContext, userId, tenantId, teamId, cancellationToken);
-            }
         }
 
         /// <summary>
@@ -668,7 +687,7 @@ namespace Icebreaker.Bot
                 optedIn[team] = optStatus;
             }
 
-            return this.dataProvider.SetUserInfoAsync(userInfo.TenantId, userInfo.Id, optedIn, userInfo.ServiceUrl, userInfo.CardToDelete);
+            return this.dataProvider.SetUserInfoAsync(userInfo.TenantId, userInfo.Id, optedIn, userInfo.ServiceUrl, userInfo.Profile, userInfo.CardToDelete);
         }
 
         /// <summary>

--- a/Source/Icebreaker/Bot/IcebreakerBot.cs
+++ b/Source/Icebreaker/Bot/IcebreakerBot.cs
@@ -512,6 +512,30 @@ namespace Icebreaker.Bot
                     };
 
                     await turnContext.SendActivityAsync(reply, cancellationToken).ConfigureAwait(false);
+
+                    break;
+
+                case "feedback":
+
+                    // add to database
+                    this.telemetryClient.TrackTrace("Received feedback");
+                    var rating = cardPayload["rating"].Value<string>();
+                    var comments = cardPayload["comments"].Value<string>();
+
+                    await this.dataProvider.AddFeedbackAsync(rating, comments, teamId);
+
+                    // send thank you message
+                    var feedbackSubmitReply = activity.CreateReply();
+                    feedbackSubmitReply.Attachments = new List<Attachment>
+                    {
+                        new HeroCard()
+                        {
+                            Text = Resources.ThankYouMessage
+                        }.ToAttachment(),
+                    };
+
+                    await turnContext.SendActivityAsync(feedbackSubmitReply, cancellationToken).ConfigureAwait(false);
+
                     break;
 
                 default:

--- a/Source/Icebreaker/Helpers/AdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCard.cs
@@ -27,6 +27,11 @@ namespace Icebreaker.Helpers
         /// <summary>
         /// Represents the welcome card sent to team channel once bot is added
         /// </summary>
-        WelcomeTeam
+        WelcomeTeam,
+
+        /// <summary>
+        /// Represents the card sent to collect user feedback
+        /// </summary>
+        Feedback
     }
 }

--- a/Source/Icebreaker/Helpers/AdaptiveCards/FeedbackAdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/FeedbackAdaptiveCard.cs
@@ -1,0 +1,42 @@
+﻿//----------------------------------------------------------------------------------------------
+// <copyright file="FeedbackAdaptiveCard.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+//----------------------------------------------------------------------------------------------
+
+namespace Icebreaker.Helpers.AdaptiveCards
+{
+    using System;
+    using global::AdaptiveCards.Templating;
+    using Icebreaker.Properties;
+    using Microsoft.Bot.Schema;
+    using Microsoft.Bot.Schema.Teams;
+
+    /// <summary>
+    /// Builder class for the pairup notification card
+    /// </summary>
+    public class FeedbackAdaptiveCard : AdaptiveCardBase
+    {
+        private static readonly Lazy<AdaptiveCardTemplate> AdaptiveCardTemplate =
+            new Lazy<AdaptiveCardTemplate>(() => CardTemplateHelper.GetAdaptiveCardTemplate(AdaptiveCardName.Feedback));
+
+        /// <summary>
+        /// Creates the pairup notification card.
+        /// </summary>
+        /// <returns>Pairup notification card</returns>
+        public static Attachment GetCard()
+        {
+            var cardData = new
+            {
+                promptFeedback = Resources.PromptFeedbackText,
+                giveFeedback = Resources.GiveFeedbackButtonText,
+                saveButton = Resources.SaveButtonText,
+                ratingText = Resources.RatingText,
+                promptComment = Resources.PromptCommentText,
+                commentPlaceholder = Resources.CommentPlaceholderText
+            };
+
+            return GetCard(AdaptiveCardTemplate.Value, cardData);
+        }
+    }
+}

--- a/Source/Icebreaker/Helpers/AdaptiveCards/FeedbackAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/FeedbackAdaptiveCard.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.0",
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "Container",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${promptFeedback}",
+          "wrap": true
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.ShowCard",
+      "title": "${giveFeedback}",
+      "card": {
+        "type": "AdaptiveCard",
+        "body": [
+          {
+            "type": "Container",
+            "items": [
+              {
+                "type": "TextBlock",
+                "text": "${ratingText}",
+                "wrap": true
+              },
+              {
+                "type": "Input.ChoiceSet",
+                "id": "rating",
+                "style": "compact",
+                "isMultiSelect": false,
+                "value": "5",
+                "choices": [
+                  {
+                    "title": "1",
+                    "value": "1"
+                  },
+                  {
+                    "title": "2",
+                    "value": "2"
+                  },
+                  {
+                    "title": "3",
+                    "value": "3"
+                  },
+                  {
+                    "title": "4",
+                    "value": "4"
+                  },
+                  {
+                    "title": "5",
+                    "value": "5"
+                  }
+                ]
+              },
+              {
+                "type": "TextBlock",
+                "text": "${promptComment}",
+                "wrap": true
+              },
+              {
+                "type": "Input.Text",
+                "id": "comments",
+                "style": "compact",
+                "placeholder": "${commentPlaceholder}",
+                "maxLength": 1000,
+                "isMultiline": true
+              }
+            ]
+          }
+        ],
+        "actions": [
+          {
+            "type": "Action.Submit",
+            "title": "${saveButton}",
+            "data": {
+              "ActionType": "feedback"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
@@ -29,35 +29,42 @@ namespace Icebreaker.Helpers.AdaptiveCards
         /// Creates the pairup notification card.
         /// </summary>
         /// <param name="teamName">The team name.</param>
-        /// <param name="sender">The user who will be sending this card.</param>
         /// <param name="recipient">The user who will be receiving this card.</param>
+        /// <param name="sender">The user who will be sending this card.</param>
+        /// <param name="senderProfile">The profile of the sender.</param>
         /// <param name="botDisplayName">The bot display name.</param>
         /// <returns>Pairup notification card</returns>
-        public static Attachment GetCard(string teamName, TeamsChannelAccount sender, TeamsChannelAccount recipient, string botDisplayName)
+        public static Attachment GetCard(string teamName, TeamsChannelAccount recipient, TeamsChannelAccount sender, string senderProfile, string botDisplayName)
         {
             // Guest users may not have their given name specified in AAD, so fall back to the full name if needed
-            var senderGivenName = string.IsNullOrEmpty(sender.GivenName) ? sender.Name : sender.GivenName;
             var recipientGivenName = string.IsNullOrEmpty(recipient.GivenName) ? recipient.Name : recipient.GivenName;
+            var senderGivenName = string.IsNullOrEmpty(sender.GivenName) ? sender.Name : sender.GivenName;
 
             // To start a chat with a guest user, use their external email, not the UPN
-            var recipientUpn = !IsGuestUser(recipient) ? recipient.UserPrincipalName : recipient.Email;
+            var senderUpn = !IsGuestUser(sender) ? sender.UserPrincipalName : sender.Email;
 
-            var meetingTitle = string.Format(Resources.MeetupTitle, senderGivenName, recipientGivenName);
+            var meetingTitle = string.Format(Resources.MeetupTitle, recipientGivenName, senderGivenName);
             var meetingContent = string.Format(Resources.MeetupContent, botDisplayName);
-            var meetingLink = "https://teams.microsoft.com/l/meeting/new?subject=" + Uri.EscapeDataString(meetingTitle) + "&attendees=" + recipientUpn + "&content=" + Uri.EscapeDataString(meetingContent);
+            var meetingLink = "https://teams.microsoft.com/l/meeting/new?subject=" + Uri.EscapeDataString(meetingTitle) + "&attendees=" + senderUpn + "&content=" + Uri.EscapeDataString(meetingContent);
 
             var cardData = new
             {
                 matchUpCardTitleContent = Resources.MatchUpCardTitleContent,
-                matchUpCardMatchedText = string.Format(Resources.MatchUpCardMatchedText, recipient.Name),
-                matchUpCardContentPart1 = string.Format(Resources.MatchUpCardContentPart1, botDisplayName, teamName, recipient.Name),
+                matchUpCardMatchedText = string.Format(Resources.MatchUpCardMatchedText, sender.Name),
+                matchUpCardContentPart1 = string.IsNullOrEmpty(senderProfile) ?
+                    string.Format(Resources.MatchUpCardContentPart1, botDisplayName, teamName, sender.Name) :
+                    string.Format(Resources.MatchUpCardContentPart1b, botDisplayName, teamName, sender.Name, senderProfile),
                 matchUpCardContentPart2 = Resources.MatchUpCardContentPart2,
-                chatWithMatchButtonText = string.Format(Resources.ChatWithMatchButtonText, recipientGivenName),
+                chatWithMatchButtonText = string.Format(Resources.ChatWithMatchButtonText, senderGivenName),
                 chatWithMessageGreeting = Resources.ChatWithMessageGreeting,
                 pauseMatchesButtonText = Resources.PausePairingsButtonText,
+                profilePlaceholderText = Resources.ProfilePlaceholderText,
                 proposeMeetupButtonText = Resources.ProposeMeetupButtonText,
-                personUpn = recipientUpn,
                 viewTeamsButton = Resources.ViewTeamsButtonText,
+                saveButtonText = Resources.SaveButtonText,
+                updateProfileButtonText = Resources.UpdateProfileButtonText,
+                updateProfileAction = Resources.UpdateProfileAction,
+                personUpn = senderUpn,
                 meetingLink,
             };
 

--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
@@ -57,6 +57,7 @@ namespace Icebreaker.Helpers.AdaptiveCards
                 pauseMatchesButtonText = Resources.PausePairingsButtonText,
                 proposeMeetupButtonText = Resources.ProposeMeetupButtonText,
                 personUpn = recipientUpn,
+                viewTeamsButton = Resources.ViewTeamsButtonText,
                 meetingLink,
             };
 

--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
@@ -66,6 +66,17 @@
           "text": "optout"
         }
       }
+    },
+    {
+      "type": "Action.Submit",
+      "title": "${viewTeamsButton}",
+      "data": {
+        "msteams": {
+          "type": "messageBack",
+          "displayText": "${viewTeamsButton}",
+          "text": "viewteams"
+        }
+      }
     }
   ],
   "version": "1.0"

--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
@@ -77,6 +77,36 @@
           "text": "viewteams"
         }
       }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "${updateProfileButtonText}",
+      "card": {
+          "type": "AdaptiveCard",
+          "body": [
+              {
+                  "type": "Container",
+                  "items": [
+                      {
+                          "type": "Input.Text",
+                          "id": "profile",
+                          "placeholder": "${profilePlaceholderText}",
+                          "maxLength": 1000,
+                          "isMultiline": true
+                      }
+                  ]
+              }
+          ],
+          "actions": [
+              {
+                  "type": "Action.Submit",
+                  "title": "${saveButtonText}",
+                  "data": {
+                      "ActionType": "${updateProfileAction}"
+                  }
+              }
+          ]
+      }
     }
   ],
   "version": "1.0"

--- a/Source/Icebreaker/Helpers/AdaptiveCards/TeamsViewCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/TeamsViewCard.cs
@@ -1,0 +1,73 @@
+﻿//----------------------------------------------------------------------------------------------
+// <copyright file="TeamsViewCard.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+//----------------------------------------------------------------------------------------------
+
+namespace Icebreaker.Helpers.AdaptiveCards
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using global::AdaptiveCards;
+    using Icebreaker.Helpers;
+    using Icebreaker.Properties;
+    using Microsoft.Bot.Schema;
+
+    /// <summary>
+    /// Class for teams view card
+    /// </summary>
+    public class TeamsViewCard
+    {
+        /// <summary>
+        /// Gets the teams view card
+        /// <param name="userInfo">User info.</param>
+        /// <param name="teamNameLookup">Team id to name</param>
+        /// </summary>
+        /// <returns>Returns an attachment of teams view card.</returns>
+        public static Attachment GetTeamsViewCard(UserInfo userInfo, Dictionary<string, string> teamNameLookup)
+        {
+            AdaptiveCard teamsViewCard = new AdaptiveCard("1.2")
+            {
+                Body = new List<AdaptiveElement>
+                {
+                    new AdaptiveTextBlock
+                    {
+                        HorizontalAlignment = AdaptiveHorizontalAlignment.Left,
+                        Text = Resources.ViewTeamsText,
+                        Wrap = true
+                    },
+                },
+                Actions = new List<AdaptiveAction>
+                {
+                    new AdaptiveSubmitAction
+                    {
+                        Title = Resources.SaveButtonText,
+                        Data = new
+                        {
+                            ActionType = "saveopt"
+                        },
+                    },
+                },
+            };
+
+            var optedIn = userInfo.OptedIn;
+            foreach (var teamId in optedIn.Keys.ToList())
+            {
+                teamsViewCard.Body.Add(new AdaptiveToggleInput
+                {
+                    Title = teamNameLookup[teamId],
+                    Id = teamId,
+                    Value = optedIn[teamId].ToString().ToLower(),
+                    ValueOff = "true",
+                    ValueOn = "false"
+                });
+            }
+
+            return new Attachment
+            {
+                ContentType = AdaptiveCard.ContentType,
+                Content = teamsViewCard,
+            };
+        }
+    }
+}

--- a/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.cs
@@ -64,7 +64,8 @@ namespace Icebreaker.Helpers.AdaptiveCards
                 pauseMatchesText = Resources.PausePairingsButtonText,
                 tourUrl = $"https://teams.microsoft.com/l/task/{appId}?url={htmlUrl}&height=533px&width=600px&title={tourTitle}",
                 salutationText = Resources.SalutationTitleText,
-                tourButtonText = Resources.TakeATourButtonText
+                tourButtonText = Resources.TakeATourButtonText,
+                viewTeamsButton = Resources.ViewTeamsButtonText
             };
 
             return GetCard(AdaptiveCardTemplate.Value, welcomeData);

--- a/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.cs
@@ -62,10 +62,14 @@ namespace Icebreaker.Helpers.AdaptiveCards
                 team = teamName,
                 welcomeCardImageUrl = $"https://{baseDomain}/Content/welcome-card-image.png",
                 pauseMatchesText = Resources.PausePairingsButtonText,
+                profilePlaceholderText = Resources.ProfilePlaceholderText,
                 tourUrl = $"https://teams.microsoft.com/l/task/{appId}?url={htmlUrl}&height=533px&width=600px&title={tourTitle}",
                 salutationText = Resources.SalutationTitleText,
+                viewTeamsButton = Resources.ViewTeamsButtonText,
+                saveButtonText = Resources.SaveButtonText,
+                setUpProfileButtonText = Resources.SetUpProfileButtonText,
                 tourButtonText = Resources.TakeATourButtonText,
-                viewTeamsButton = Resources.ViewTeamsButtonText
+                updateProfileAction = Resources.UpdateProfileAction,
             };
 
             return GetCard(AdaptiveCardTemplate.Value, welcomeData);

--- a/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
@@ -69,6 +69,36 @@
           "text": "viewteams"
         }
       }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "${setUpProfileButtonText}",
+      "card": {
+          "type": "AdaptiveCard",
+          "body": [
+              {
+                  "type": "Container",
+                  "items": [
+                      {
+                          "type": "Input.Text",
+                          "id": "profile",
+                          "placeholder": "${profilePlaceholderText}",
+                          "maxLength": 1000,
+                          "isMultiline": true
+                      }
+                  ]
+              }
+          ],
+          "actions": [
+              {
+                  "type": "Action.Submit",
+                  "title": "${saveButtonText}",
+                  "data": {
+                      "ActionType": "${updateProfileAction}"
+                  }
+              }
+          ]
+      }
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
@@ -58,6 +58,17 @@
           "text": "optout"
         }
       }
+    },
+    {
+      "type": "Action.Submit",
+      "title": "${viewTeamsButton}",
+      "data": {
+        "msteams": {
+          "type": "messageBack",
+          "displayText": "${viewTeamsButton}",
+          "text": "viewteams"
+        }
+      }
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
+++ b/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
@@ -242,15 +242,63 @@ namespace Icebreaker.Helpers
         }
 
         /// <summary>
+        /// Get the stored profiles of given users
+        /// </summary>
+        /// <returns>User's custom profiles</returns>
+        public async Task<Dictionary<string, string>> GetAllUsersProfileAsync()
+        {
+            await this.EnsureInitializedAsync();
+
+            try
+            {
+                var collectionLink = UriFactory.CreateDocumentCollectionUri(this.database.Id, this.usersCollection.Id);
+                var query = this.documentClient.CreateDocumentQuery<UserInfo>(
+                        collectionLink,
+#pragma warning disable SA1118 // Parameter must not span multiple lines
+                        new FeedOptions
+                        {
+                            EnableCrossPartitionQuery = true,
+
+                            // Fetch items in bulk according to DB engine capability
+                            MaxItemCount = -1,
+
+                            // Max partition to query at a time
+                            MaxDegreeOfParallelism = -1
+                        })
+#pragma warning restore SA1118 // Parameter must not span multiple lines
+                    .Select(u => new UserInfo { Id = u.Id, Profile = u.Profile })
+                    .AsDocumentQuery();
+                var usersProfileLookup = new Dictionary<string, string>();
+                while (query.HasMoreResults)
+                {
+                    // Note that ExecuteNextAsync can return many records in each call
+                    var responseBatch = await query.ExecuteNextAsync<UserInfo>();
+                    foreach (var userInfo in responseBatch)
+                    {
+                        usersProfileLookup.Add(userInfo.Id, userInfo.Profile);
+                    }
+                }
+
+                return usersProfileLookup;
+            }
+            catch (Exception ex)
+            {
+                this.telemetryClient.TrackException(ex.InnerException);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Set the user info for the given user
         /// </summary>
         /// <param name="tenantId">Tenant id</param>
         /// <param name="userId">User id</param>
         /// <param name="optedIn">User opt-in status for each team user is in</param>
         /// <param name="serviceUrl">User service URL</param>
+        /// <param name="profile">User profile</param>
         /// <param name="cardToDelete">Activity id of card to be deleted</param>
         /// <returns>Tracking task</returns>
-        public async Task SetUserInfoAsync(string tenantId, string userId, IDictionary<string, bool> optedIn, string serviceUrl, string cardToDelete)
+        public async Task SetUserInfoAsync(string tenantId, string userId, IDictionary<string, bool> optedIn, string serviceUrl, string profile, string cardToDelete)
         {
             await this.EnsureInitializedAsync();
 
@@ -260,6 +308,7 @@ namespace Icebreaker.Helpers
                 UserId = userId,
                 OptedIn = optedIn,
                 ServiceUrl = serviceUrl,
+                Profile = profile,
                 CardToDelete = cardToDelete
             };
             await this.documentClient.UpsertDocumentAsync(this.usersCollection.SelfLink, userInfo);
@@ -282,7 +331,7 @@ namespace Icebreaker.Helpers
             var optedIn = userInfo?.OptedIn ?? new Dictionary<string, bool>();
             optedIn.Add(teamId, true);
 
-            await this.SetUserInfoAsync(tenantId, userId, optedIn, serviceUrl, userInfo?.CardToDelete);
+            await this.SetUserInfoAsync(tenantId, userId, optedIn, serviceUrl, userInfo?.Profile, userInfo?.CardToDelete);
         }
 
         /// <summary>
@@ -300,7 +349,7 @@ namespace Icebreaker.Helpers
             var optedIn = userInfo.OptedIn;
             optedIn.Remove(teamId);
 
-            await this.SetUserInfoAsync(userInfo.TenantId, userId, optedIn, userInfo.ServiceUrl, userInfo.CardToDelete);
+            await this.SetUserInfoAsync(userInfo.TenantId, userId, optedIn, userInfo.ServiceUrl, userInfo.Profile, userInfo.CardToDelete);
         }
 
         /// <summary>

--- a/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
+++ b/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
@@ -35,6 +35,7 @@ namespace Icebreaker.Helpers
         private DocumentCollection pairsCollection;
         private DocumentCollection teamsCollection;
         private DocumentCollection usersCollection;
+        private DocumentCollection feedbackCollection;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IcebreakerBotDataProvider"/> class.
@@ -195,7 +196,7 @@ namespace Icebreaker.Helpers
         }
 
         /// <summary>
-        /// Get the stored information about given users
+        /// Get the stored opt-in information about given users
         /// </summary>
         /// <returns>User information</returns>
         public async Task<Dictionary<string, IDictionary<string, bool>>> GetAllUsersOptInStatusAsync()
@@ -353,6 +354,26 @@ namespace Icebreaker.Helpers
         }
 
         /// <summary>
+        /// Adds feedback
+        /// </summary>
+        /// <param name="feedbackRating">User numerical rating</param>
+        /// <param name="feedbackText">Text of user comment</param>
+        /// <param name="teamId">Team id</param>
+        /// <returns>Tracking task</returns>
+        public async Task AddFeedbackAsync(string feedbackRating, string feedbackText, string teamId)
+        {
+            await this.EnsureInitializedAsync();
+
+            var userFeedback = new UserFeedback
+            {
+                FeedbackRating = feedbackRating,
+                FeedbackText = feedbackText,
+                TeamId = teamId
+            };
+            await this.documentClient.UpsertDocumentAsync(this.feedbackCollection.SelfLink, userFeedback);
+        }
+
+        /// <summary>
         /// Initializes the database connection.
         /// </summary>
         /// <returns>Tracking task</returns>
@@ -365,6 +386,7 @@ namespace Icebreaker.Helpers
             var pairsCollectionName = CloudConfigurationManager.GetSetting("CosmosCollectionPairs");
             var teamsCollectionName = CloudConfigurationManager.GetSetting("CosmosCollectionTeams");
             var usersCollectionName = CloudConfigurationManager.GetSetting("CosmosCollectionUsers");
+            var feedbackCollectionName = CloudConfigurationManager.GetSetting("CosmosCollectionFeedback");
 
             this.documentClient = new DocumentClient(new Uri(endpointUrl), this.secretsHelper.CosmosDBKey);
 
@@ -414,6 +436,14 @@ namespace Icebreaker.Helpers
             };
             usersCollectionDefinition.PartitionKey.Paths.Add("/id");
             this.usersCollection = await this.documentClient.CreateDocumentCollectionIfNotExistsAsync(this.database.SelfLink, usersCollectionDefinition, useSharedOffer ? null : requestOptions);
+
+            // Get a reference to the Feedback collection, creating it if needed
+            var feedbackCollectionDefinition = new DocumentCollection
+            {
+                Id = feedbackCollectionName
+            };
+            feedbackCollectionDefinition.PartitionKey.Paths.Add("/id");
+            this.feedbackCollection = await this.documentClient.CreateDocumentCollectionIfNotExistsAsync(this.database.SelfLink, feedbackCollectionDefinition, useSharedOffer ? null : requestOptions);
 
             this.telemetryClient.TrackTrace("Data store initialized");
         }

--- a/Source/Icebreaker/Helpers/TeamInstallInfo.cs
+++ b/Source/Icebreaker/Helpers/TeamInstallInfo.cs
@@ -8,6 +8,7 @@ namespace Icebreaker.Helpers
 {
     using Microsoft.Azure.Documents;
     using Newtonsoft.Json;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Represents information about a team to which the Icebreaker app was installed
@@ -42,6 +43,12 @@ namespace Icebreaker.Helpers
         /// </summary>
         [JsonProperty("installerName")]
         public string InstallerName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the channel ids of the users on the team
+        /// </summary>
+        [JsonProperty("userIds")]
+        public ISet<string> UserIds { get; set; }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/Source/Icebreaker/Helpers/UserFeedback.cs
+++ b/Source/Icebreaker/Helpers/UserFeedback.cs
@@ -1,0 +1,35 @@
+//----------------------------------------------------------------------------------------------
+// <copyright file="UserFeedback.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+//----------------------------------------------------------------------------------------------
+
+namespace Icebreaker.Helpers
+{
+    using Microsoft.Azure.Documents;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Represents a user
+    /// </summary>
+    public class UserFeedback : Document
+    {
+        /// <summary>
+        /// Gets or sets the id of the associated
+        /// </summary>
+        [JsonProperty("teamId")]
+        public string TeamId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's rating
+        /// </summary>
+        [JsonProperty("feedbackRating")]
+        public string FeedbackRating { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text of the comment by the user
+        /// </summary>
+        [JsonProperty("feedbackText")]
+        public string FeedbackText { get; set; }
+    }
+}

--- a/Source/Icebreaker/Helpers/UserInfo.cs
+++ b/Source/Icebreaker/Helpers/UserInfo.cs
@@ -55,5 +55,11 @@ namespace Icebreaker.Helpers
         /// </summary>
         [JsonProperty("recentPairups")]
         public List<UserInfo> RecentPairUps { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's profile
+        /// </summary>
+        [JsonProperty("profile")]
+        public string Profile { get; set; }
     }
 }

--- a/Source/Icebreaker/Helpers/UserInfo.cs
+++ b/Source/Icebreaker/Helpers/UserInfo.cs
@@ -39,10 +39,16 @@ namespace Icebreaker.Helpers
         public string ServiceUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the user is opted in to pairups
+        /// Gets or sets dictionary mapping team channel id to user's opt-in status for that team
         /// </summary>
         [JsonProperty("optedIn")]
-        public bool OptedIn { get; set; }
+        public IDictionary<string, bool> OptedIn { get; set; }
+
+        /// <summary>
+        /// Gets or sets activity id of the card to be deleted on next message activity
+        /// </summary>
+        [JsonProperty("cardToDelete")]
+        public string CardToDelete { get; set; }
 
         /// <summary>
         /// Gets or sets a list of recent pairups

--- a/Source/Icebreaker/Icebreaker.csproj
+++ b/Source/Icebreaker/Icebreaker.csproj
@@ -327,6 +327,7 @@
     <Compile Include="Controllers\ProcessNowController.cs" />
     <Compile Include="Helpers\AdaptiveCard.cs" />
     <Compile Include="Helpers\AdaptiveCards\AdaptiveCardBase.cs" />
+    <Compile Include="Helpers\AdaptiveCards\TeamsViewCard.cs" />
     <Compile Include="Helpers\CardTemplateHelper.cs" />
     <Compile Include="Helpers\MatchingActions.cs" />
     <Compile Include="Helpers\SecretsHelper.cs" />

--- a/Source/Icebreaker/Icebreaker.csproj
+++ b/Source/Icebreaker/Icebreaker.csproj
@@ -328,6 +328,7 @@
     <Compile Include="Helpers\AdaptiveCard.cs" />
     <Compile Include="Helpers\AdaptiveCards\AdaptiveCardBase.cs" />
     <Compile Include="Helpers\AdaptiveCards\TeamsViewCard.cs" />
+    <Compile Include="Helpers\AdaptiveCards\FeedbackAdaptiveCard.cs" />
     <Compile Include="Helpers\CardTemplateHelper.cs" />
     <Compile Include="Helpers\MatchingActions.cs" />
     <Compile Include="Helpers\SecretsHelper.cs" />
@@ -347,6 +348,7 @@
     <Compile Include="Helpers\PairInfo.cs" />
     <Compile Include="Helpers\TeamInstallInfo.cs" />
     <Compile Include="Helpers\UserInfo.cs" />
+    <Compile Include="Helpers\UserFeedback.cs" />
     <Compile Include="IcebreakerModule.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
@@ -373,6 +375,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="lib\microsoft-teams\dist\MicrosoftTeams.js.map" />
+    <Content Include="Helpers\AdaptiveCards\FeedbackAdaptiveCard.json" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/Source/Icebreaker/Interfaces/IBotDataProvider.cs
+++ b/Source/Icebreaker/Interfaces/IBotDataProvider.cs
@@ -25,7 +25,7 @@ namespace Icebreaker.Interfaces
         /// Get the stored information about given users
         /// </summary>
         /// <returns>User information</returns>
-        Task<Dictionary<string, bool>> GetAllUsersOptInStatusAsync();
+        Task<Dictionary<string, IDictionary<string, bool>>> GetAllUsersOptInStatusAsync();
 
         /// <summary>
         /// Returns the team that the bot has been installed to
@@ -43,14 +43,40 @@ namespace Icebreaker.Interfaces
         Task UpdateTeamInstallStatusAsync(TeamInstallInfo team, bool installed);
 
         /// <summary>
+        /// Get the stored information about the given user
+        /// </summary>
+        /// <param name="userId">User id</param>
+        /// <returns>User information</returns>
+        Task<UserInfo> GetUserInfoAsync(string userId);
+
+        /// <summary>
         /// Set the user info for the given user
         /// </summary>
         /// <param name="tenantId">Tenant id</param>
         /// <param name="userId">User id</param>
-        /// <param name="optedIn">User opt-in status</param>
+        /// <param name="optedIn">User opt-in status for each team user is in</param>
+        /// <param name="serviceUrl">User service URL</param>
+        /// <param name="cardToDelete">Activity id of card to be deleted</param>
+        /// <returns>Tracking task</returns>
+        Task SetUserInfoAsync(string tenantId, string userId, IDictionary<string, bool> optedIn, string serviceUrl, string cardToDelete);
+
+        /// <summary>
+        /// Add team to user's teams
+        /// </summary>
+        /// <param name="tenantId">Tenant id</param>
+        /// <param name="userId">User id</param>
+        /// <param name="teamId">Team to add</param>
         /// <param name="serviceUrl">User service URL</param>
         /// <returns>Tracking task</returns>
-        Task SetUserInfoAsync(string tenantId, string userId, bool optedIn, string serviceUrl);
+        Task AddUserTeamAsync(string tenantId, string userId, string teamId, string serviceUrl);
+
+        /// <summary>
+        /// Remove team from user's teams
+        /// </summary>
+        /// <param name="userId">User id</param>
+        /// <param name="teamId">Team to remove</param>
+        /// <returns>Tracking task</returns>
+        Task RemoveUserTeamAsync(string userId, string teamId);
 
         /// <summary>
         /// Get a list of past pairings

--- a/Source/Icebreaker/Interfaces/IBotDataProvider.cs
+++ b/Source/Icebreaker/Interfaces/IBotDataProvider.cs
@@ -28,6 +28,12 @@ namespace Icebreaker.Interfaces
         Task<Dictionary<string, IDictionary<string, bool>>> GetAllUsersOptInStatusAsync();
 
         /// <summary>
+        /// Get the stored profiles of given users
+        /// </summary>
+        /// <returns>User's custom profiles</returns>
+        Task<Dictionary<string, string>> GetAllUsersProfileAsync();
+
+        /// <summary>
         /// Returns the team that the bot has been installed to
         /// </summary>
         /// <param name="teamId">The team id</param>
@@ -56,9 +62,10 @@ namespace Icebreaker.Interfaces
         /// <param name="userId">User id</param>
         /// <param name="optedIn">User opt-in status for each team user is in</param>
         /// <param name="serviceUrl">User service URL</param>
+        /// <param name="profile">User profile</param>
         /// <param name="cardToDelete">Activity id of card to be deleted</param>
         /// <returns>Tracking task</returns>
-        Task SetUserInfoAsync(string tenantId, string userId, IDictionary<string, bool> optedIn, string serviceUrl, string cardToDelete);
+        Task SetUserInfoAsync(string tenantId, string userId, IDictionary<string, bool> optedIn, string serviceUrl, string profile, string cardToDelete);
 
         /// <summary>
         /// Add team to user's teams

--- a/Source/Icebreaker/Interfaces/IBotDataProvider.cs
+++ b/Source/Icebreaker/Interfaces/IBotDataProvider.cs
@@ -86,6 +86,15 @@ namespace Icebreaker.Interfaces
         Task RemoveUserTeamAsync(string userId, string teamId);
 
         /// <summary>
+        /// Adds feedback
+        /// </summary>
+        /// <param name="feedbackRating">User rating</param>
+        /// <param name="feedbackText">Text of user comment</param>
+        /// <param name="teamId">Team id</param>
+        /// <returns>Tracking task</returns>
+        Task AddFeedbackAsync(string feedbackRating, string feedbackText, string teamId);
+
+        /// <summary>
         /// Get a list of past pairings
         /// </summary>
         /// <returns>List of past pairings.</returns>

--- a/Source/Icebreaker/Properties/Resources.Designer.cs
+++ b/Source/Icebreaker/Properties/Resources.Designer.cs
@@ -167,6 +167,15 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("MatchUpCardContentPart1", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hi there again, I&apos;m {0} in {1}. A bot that pairs you with a new coworker to meet each week. This week your match is {2}. Here is something they wanted to let you know about them: {3}..
+        /// </summary>
+        internal static string MatchUpCardContentPart1b {
+            get {
+                return ResourceManager.GetString("MatchUpCardContentPart1b", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to If you&apos;ve got the inclination, set something up. See, meeting people *is* easy!.
@@ -248,7 +257,16 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("PausePairingsButtonText", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Share something about yourself with future matches!.
+        /// </summary>
+        internal static string ProfilePlaceholderText {
+            get {
+                return ResourceManager.GetString("ProfilePlaceholderText", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Propose meetup.
         /// </summary>
@@ -275,7 +293,7 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("SalutationTitleText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Save.
         /// </summary>
@@ -295,11 +313,47 @@ namespace Icebreaker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Set up profile.
+        /// </summary>
+        internal static string SetUpProfileButtonText {
+            get {
+                return ResourceManager.GetString("SetUpProfileButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to I&apos;m sorry, but I can&apos;t process the incoming message. You can take a tour, though, to learn more about my functionality..
         /// </summary>
         internal static string UnrecognizedInput {
             get {
                 return ResourceManager.GetString("UnrecognizedInput", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Update profile.
+        /// </summary>
+        internal static string UpdateProfileButtonText {
+            get {
+                return ResourceManager.GetString("UpdateProfileButtonText", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to update.
+        /// </summary>
+        internal static string UpdateProfileAction {
+            get {
+                return ResourceManager.GetString("UpdateProfileAction", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Your profile has been updated!
+        /// </summary>
+        internal static string UpdateProfileConfirmation {
+            get {
+                return ResourceManager.GetString("UpdateProfileConfirmation", resourceCulture);
             }
         }
         

--- a/Source/Icebreaker/Properties/Resources.Designer.cs
+++ b/Source/Icebreaker/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Icebreaker.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -61,6 +61,15 @@ namespace Icebreaker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Your preferences have been updated. Here are the teams you&apos;re currently matching for:.
+        /// </summary>
+        internal static string ActiveTeamsText {
+            get {
+                return ResourceManager.GetString("ActiveTeamsText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Chat with {0}.
         /// </summary>
         internal static string ChatWithMatchButtonText {
@@ -75,6 +84,15 @@ namespace Icebreaker.Properties {
         internal static string ChatWithMessageGreeting {
             get {
                 return ResourceManager.GetString("ChatWithMessageGreeting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edit active teams.
+        /// </summary>
+        internal static string EditActiveTeamsButtonText {
+            get {
+                return ResourceManager.GetString("EditActiveTeamsButtonText", resourceCulture);
             }
         }
         
@@ -196,6 +214,15 @@ namespace Icebreaker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are not currently matching for any teams..
+        /// </summary>
+        internal static string NoActiveTeamsMessage {
+            get {
+                return ResourceManager.GetString("NoActiveTeamsMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Welcome back! You&apos;ve been missed. I&apos;ve restarted your matches. Have fun!.
         /// </summary>
         internal static string OptInConfirmation {
@@ -250,6 +277,15 @@ namespace Icebreaker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Save.
+        /// </summary>
+        internal static string SaveButtonText {
+            get {
+                return ResourceManager.GetString("SaveButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Take a tour.
         /// </summary>
         internal static string TakeATourButtonText {
@@ -264,6 +300,24 @@ namespace Icebreaker.Properties {
         internal static string UnrecognizedInput {
             get {
                 return ResourceManager.GetString("UnrecognizedInput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View my teams.
+        /// </summary>
+        internal static string ViewTeamsButtonText {
+            get {
+                return ResourceManager.GetString("ViewTeamsButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Here are your teams! Select the teams that you would like to pause matches for..
+        /// </summary>
+        internal static string ViewTeamsText {
+            get {
+                return ResourceManager.GetString("ViewTeamsText", resourceCulture);
             }
         }
         

--- a/Source/Icebreaker/Properties/Resources.Designer.cs
+++ b/Source/Icebreaker/Properties/Resources.Designer.cs
@@ -88,20 +88,20 @@ namespace Icebreaker.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Edit active teams.
-        /// </summary>
-        internal static string EditActiveTeamsButtonText {
-            get {
-                return ResourceManager.GetString("EditActiveTeamsButtonText", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to Tell us your thoughts!.
         /// </summary>
         internal static string CommentPlaceholderText {
             get {
                 return ResourceManager.GetString("CommentPlaceholderText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edit active teams.
+        /// </summary>
+        internal static string EditActiveTeamsButtonText {
+            get {
+                return ResourceManager.GetString("EditActiveTeamsButtonText", resourceCulture);
             }
         }
         
@@ -185,9 +185,9 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("MatchUpCardContentPart1", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Hi there again, I&apos;m {0} in {1}. A bot that pairs you with a new coworker to meet each week. This week your match is {2}. Here is something they wanted to let you know about them: {3}..
+        ///   Looks up a localized string similar to Hi there again, I&apos;m {0} in {1}. A bot that pairs you with a new coworker to meet each week. This week your match is {2}. Here is something they wanted to let you know about them: {3}.
         /// </summary>
         internal static string MatchUpCardContentPart1b {
             get {
@@ -275,7 +275,7 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("PausePairingsButtonText", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Share something about yourself with future matches!.
         /// </summary>
@@ -284,7 +284,7 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("ProfilePlaceholderText", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Explain your rating or let us know any thoughts you have about Icebreaker..
         /// </summary>
@@ -338,7 +338,7 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("SalutationTitleText", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Save.
         /// </summary>
@@ -349,11 +349,11 @@ namespace Icebreaker.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Save.
+        ///   Looks up a localized string similar to Set up Profile.
         /// </summary>
-        internal static string SaveButtonText {
+        internal static string SetUpProfileButtonText {
             get {
-                return ResourceManager.GetString("SaveButtonText", resourceCulture);
+                return ResourceManager.GetString("SetUpProfileButtonText", resourceCulture);
             }
         }
         
@@ -366,15 +366,6 @@ namespace Icebreaker.Properties {
             }
         }
         
-        /// <summary>
-        ///   Looks up a localized string similar to Set up profile.
-        /// </summary>
-        internal static string SetUpProfileButtonText {
-            get {
-                return ResourceManager.GetString("SetUpProfileButtonText", resourceCulture);
-            }
-        }
-
         /// <summary>
         ///   Looks up a localized string similar to Thank you, your feedback is appreciated!.
         /// </summary>
@@ -392,16 +383,7 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("UnrecognizedInput", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Update profile.
-        /// </summary>
-        internal static string UpdateProfileButtonText {
-            get {
-                return ResourceManager.GetString("UpdateProfileButtonText", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to update.
         /// </summary>
@@ -410,9 +392,18 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("UpdateProfileAction", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Your profile has been updated!
+        ///   Looks up a localized string similar to Update Profile.
+        /// </summary>
+        internal static string UpdateProfileButtonText {
+            get {
+                return ResourceManager.GetString("UpdateProfileButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your profile has been updated!.
         /// </summary>
         internal static string UpdateProfileConfirmation {
             get {

--- a/Source/Icebreaker/Properties/Resources.Designer.cs
+++ b/Source/Icebreaker/Properties/Resources.Designer.cs
@@ -95,6 +95,15 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("EditActiveTeamsButtonText", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tell us your thoughts!.
+        /// </summary>
+        internal static string CommentPlaceholderText {
+            get {
+                return ResourceManager.GetString("CommentPlaceholderText", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to There was an error while processing request. Retry?.
@@ -102,6 +111,15 @@ namespace Icebreaker.Properties {
         internal static string ErrorOccured {
             get {
                 return ResourceManager.GetString("ErrorOccured", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Give feedback.
+        /// </summary>
+        internal static string GiveFeedbackButtonText {
+            get {
+                return ResourceManager.GetString("GiveFeedbackButtonText", resourceCulture);
             }
         }
         
@@ -160,7 +178,7 @@ namespace Icebreaker.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hi there again, I&apos;m {0} in {1}. A bot that pairs you with a new coworker to meet each week. This week your match is {2}..
+        ///   Looks up a localized string similar to Hi there again, I&apos;m {0} in {1}. A bot that pairs you with a new coworker to meet each week. How fun and exciting!! This week your match is {2}..
         /// </summary>
         internal static string MatchUpCardContentPart1 {
             get {
@@ -187,7 +205,7 @@ namespace Icebreaker.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You&apos;ve been matched with {0}..
+        ///   Looks up a localized string similar to You&apos;ve been matched with {0}. Congrats!!.
         /// </summary>
         internal static string MatchUpCardMatchedText {
             get {
@@ -268,11 +286,38 @@ namespace Icebreaker.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Explain your rating or let us know any thoughts you have about Icebreaker..
+        /// </summary>
+        internal static string PromptCommentText {
+            get {
+                return ResourceManager.GetString("PromptCommentText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to How is your experience with Icebreaker?.
+        /// </summary>
+        internal static string PromptFeedbackText {
+            get {
+                return ResourceManager.GetString("PromptFeedbackText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Propose meetup.
         /// </summary>
         internal static string ProposeMeetupButtonText {
             get {
                 return ResourceManager.GetString("ProposeMeetupButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rate your experience with Icebreaker..
+        /// </summary>
+        internal static string RatingText {
+            get {
+                return ResourceManager.GetString("RatingText", resourceCulture);
             }
         }
         
@@ -304,6 +349,15 @@ namespace Icebreaker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Save.
+        /// </summary>
+        internal static string SaveButtonText {
+            get {
+                return ResourceManager.GetString("SaveButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Take a tour.
         /// </summary>
         internal static string TakeATourButtonText {
@@ -318,6 +372,15 @@ namespace Icebreaker.Properties {
         internal static string SetUpProfileButtonText {
             get {
                 return ResourceManager.GetString("SetUpProfileButtonText", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Thank you, your feedback is appreciated!.
+        /// </summary>
+        internal static string ThankYouMessage {
+            get {
+                return ResourceManager.GetString("ThankYouMessage", resourceCulture);
             }
         }
         

--- a/Source/Icebreaker/Properties/Resources.resx
+++ b/Source/Icebreaker/Properties/Resources.resx
@@ -165,6 +165,10 @@
     <value>Hi there again, I'm {0} in {1}. A bot that pairs you with a new coworker to meet each week. This week your match is {2}.</value>
     <comment>First part of the match up card main content</comment>
   </data>
+  <data name="MatchUpCardContentPart1b" xml:space="preserve">
+    <value>Hi there again, I'm {0} in {1}. A bot that pairs you with a new coworker to meet each week. This week your match is {2}. Here is something they wanted to let you know about them: {3}</value>
+    <comment>First part of the match up card main content for users that have a profile</comment>
+  </data>
   <data name="MatchUpCardContentPart2" xml:space="preserve">
     <value>If you've got the inclination, set something up. See, meeting people *is* easy!</value>
     <comment>Second part of the match up card main content</comment>
@@ -201,6 +205,10 @@
     <value>Pause all matches</value>
     <comment>Button text to pause pairings</comment>
   </data>
+  <data name="ProfilePlaceholderText" xml:space="preserve">
+    <value>Share something about yourself with future matches!</value>
+    <comment>Placeholder for textbox when updating profile.</comment>
+  </data>
   <data name="ProposeMeetupButtonText" xml:space="preserve">
     <value>Propose meetup</value>
     <comment>Button text to propose the meetup with the match of the user</comment>
@@ -217,6 +225,10 @@
     <value>Save</value>
     <comment>Button to save preferences</comment>
   </data>
+  <data name="SetUpProfileButtonText" xml:space="preserve">
+    <value>Set up Profile</value>
+    <comment>Button text to set up profile</comment>
+  </data>
   <data name="TakeATourButtonText" xml:space="preserve">
     <value>Take a tour</value>
     <comment>The text for the button which launches a tour when clicked</comment>
@@ -232,6 +244,18 @@
   <data name="ViewTeamsText" xml:space="preserve">
     <value>Here are your teams! Select the teams that you would like to pause matches for.</value>
     <comment>Text on card where user can edit team matching preferences</comment>
+  </data>
+  <data name="UpdateProfileAction" xml:space="preserve">
+    <value>update</value>
+    <comment>Action text for updating profile</comment>
+  </data>
+  <data name="UpdateProfileButtonText" xml:space="preserve">
+    <value>Update Profile</value>
+    <comment>Button text to update profile</comment>
+  </data>
+  <data name="UpdateProfileConfirmation" xml:space="preserve">
+    <value>Your profile has been updated!</value>
+    <comment>The confirmation reply that is sent when the user updates the profile</comment>
   </data>
   <data name="WelcomeTourTitle" xml:space="preserve">
     <value>Tour</value>

--- a/Source/Icebreaker/Properties/Resources.resx
+++ b/Source/Icebreaker/Properties/Resources.resx
@@ -133,9 +133,17 @@
     <value>Edit active teams</value>
     <comment>Button text to edit teams that the user is currently matching in</comment>
   </data>
+  <data name="CommentPlaceholderText" xml:space="preserve">
+    <value>Tell us your thoughts!</value>
+    <comment>Placeholder text in comments box on feedback card</comment>
+  </data>
   <data name="ErrorOccured" xml:space="preserve">
     <value>There was an error while processing request. Retry?</value>
     <comment>A generic message that is sent when there is an error occurring</comment>
+  </data>
+  <data name="GiveFeedbackButtonText" xml:space="preserve">
+    <value>Give feedback</value>
+    <comment>Button text to give feedback</comment>
   </data>
   <data name="InstallMessageKnownInstallerPart1" xml:space="preserve">
     <value>If you're reading this, it's most likely because {0} added me to the **{1} Team.**</value>
@@ -162,7 +170,7 @@
     <comment>Part 3 of the install message when the name of the installer is not known</comment>
   </data>
   <data name="MatchUpCardContentPart1" xml:space="preserve">
-    <value>Hi there again, I'm {0} in {1}. A bot that pairs you with a new coworker to meet each week. This week your match is {2}.</value>
+    <value>Hi there again, I'm {0} in {1}. A bot that pairs you with a new coworker to meet each week. How fun and exciting!! This week your match is {2}.</value>
     <comment>First part of the match up card main content</comment>
   </data>
   <data name="MatchUpCardContentPart1b" xml:space="preserve">
@@ -174,7 +182,7 @@
     <comment>Second part of the match up card main content</comment>
   </data>
   <data name="MatchUpCardMatchedText" xml:space="preserve">
-    <value>You've been matched with {0}.</value>
+    <value>You've been matched with {0}. Congrats!!</value>
     <comment>The text saying who the user has been matched up with</comment>
   </data>
   <data name="MatchUpCardTitleContent" xml:space="preserve">
@@ -209,9 +217,21 @@
     <value>Share something about yourself with future matches!</value>
     <comment>Placeholder for textbox when updating profile.</comment>
   </data>
+  <data name="PromptCommentText" xml:space="preserve">
+    <value>Explain your rating or let us know any thoughts you have about Icebreaker.</value>
+    <comment>Text above comments box on feedback card</comment>
+  </data>
+  <data name="PromptFeedbackText" xml:space="preserve">
+    <value>How is your experience with Icebreaker?</value>
+    <comment>The text on the card to prompt user feedback</comment>
+  </data>
   <data name="ProposeMeetupButtonText" xml:space="preserve">
     <value>Propose meetup</value>
     <comment>Button text to propose the meetup with the match of the user</comment>
+  </data>
+  <data name="RatingText" xml:space="preserve">
+    <value>Rate your experience with Icebreaker.</value>
+    <comment>Text above rating dropdown on feedback card</comment>
   </data>
   <data name="ResumePairingsButtonText" xml:space="preserve">
     <value>Resume matches</value>
@@ -232,6 +252,10 @@
   <data name="TakeATourButtonText" xml:space="preserve">
     <value>Take a tour</value>
     <comment>The text for the button which launches a tour when clicked</comment>
+  </data>
+  <data name="ThankYouMessage" xml:space="preserve">
+    <value>Thank you, your feedback is appreciated!</value>
+    <comment>The thank you message sent when feedback is submitted</comment>
   </data>
   <data name="UnrecognizedInput" xml:space="preserve">
     <value>I'm sorry, but I can't process the incoming message. You can take a tour, though, to learn more about my functionality.</value>

--- a/Source/Icebreaker/Properties/Resources.resx
+++ b/Source/Icebreaker/Properties/Resources.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ActiveTeamsText" xml:space="preserve">
+    <value>Your preferences have been updated. Here are the teams you're currently matching for:</value>
+    <comment>Text on the card showing a user's currently matching teams</comment>
+  </data>
   <data name="ChatWithMatchButtonText" xml:space="preserve">
     <value>Chat with {0}</value>
     <comment>Button text to initiate a chat with the person the user has been matched up with</comment>
@@ -124,6 +128,10 @@
   <data name="ChatWithMessageGreeting" xml:space="preserve">
     <value>Hi%20there%20</value>
     <comment>This is the greeting of the chat with matched member message</comment>
+  </data>
+  <data name="EditActiveTeamsButtonText" xml:space="preserve">
+    <value>Edit active teams</value>
+    <comment>Button text to edit teams that the user is currently matching in</comment>
   </data>
   <data name="ErrorOccured" xml:space="preserve">
     <value>There was an error while processing request. Retry?</value>
@@ -177,6 +185,10 @@
     <value>{0} / {1} Meet up</value>
     <comment>The title for the Meetup - {0} is the name of the first person that user has been matched with and {1} is the name of the user</comment>
   </data>
+  <data name="NoActiveTeamsMessage" xml:space="preserve">
+    <value>You are not currently matching for any teams.</value>
+    <comment>Text that is displayed on the active teams card if the user has no active teams</comment>
+  </data>
   <data name="OptInConfirmation" xml:space="preserve">
     <value>Welcome back! You've been missed. I've restarted your matches. Have fun!</value>
     <comment>The confirmation reply that is sent when the user resumes the matches</comment>
@@ -201,6 +213,10 @@
     <value>Hi there!</value>
     <comment>This is the text for the salutation in the adaptive cards when the bot is installed to a team and also when new users are added to the team</comment>
   </data>
+  <data name="SaveButtonText" xml:space="preserve">
+    <value>Save</value>
+    <comment>Button to save preferences</comment>
+  </data>
   <data name="TakeATourButtonText" xml:space="preserve">
     <value>Take a tour</value>
     <comment>The text for the button which launches a tour when clicked</comment>
@@ -208,6 +224,14 @@
   <data name="UnrecognizedInput" xml:space="preserve">
     <value>I'm sorry, but I can't process the incoming message. You can take a tour, though, to learn more about my functionality.</value>
     <comment>The text for the unrecognized input scenario</comment>
+  </data>
+  <data name="ViewTeamsButtonText" xml:space="preserve">
+    <value>View my teams</value>
+    <comment>Button text to show team pausing preferences card</comment>
+  </data>
+  <data name="ViewTeamsText" xml:space="preserve">
+    <value>Here are your teams! Select the teams that you would like to pause matches for.</value>
+    <comment>Text on card where user can edit team matching preferences</comment>
   </data>
   <data name="WelcomeTourTitle" xml:space="preserve">
     <value>Tour</value>

--- a/Source/Icebreaker/Services/MatchingService.cs
+++ b/Source/Icebreaker/Services/MatchingService.cs
@@ -170,19 +170,19 @@ namespace Icebreaker.Services
         /// <param name="dbMembersLookup">Lookup of DB users opt-in status</param>
         /// <param name="teamInfo">The team that the bot has been installed to</param>
         /// <returns>Opted in users' channels</returns>
-        private async Task<List<ChannelAccount>> GetOptedInUsersAsync(Dictionary<string, bool> dbMembersLookup, TeamInstallInfo teamInfo)
+        private async Task<List<ChannelAccount>> GetOptedInUsersAsync(Dictionary<string, IDictionary<string, bool>> dbMembersLookup, TeamInstallInfo teamInfo)
         {
             // Pull the roster of specified team and then remove everyone who has opted out explicitly
             var members = await this.conversationHelper.GetTeamMembers(this.botAdapter, teamInfo);
 
-            this.telemetryClient.TrackTrace($"Found {members.Count} in team {teamInfo.TeamId}");
+            this.telemetryClient.TrackTrace($"Found {members.Count} in team {teamInfo.Id}");
 
             return members
                 .Where(member => member != null)
                 .Where(member =>
                 {
                     var memberObjectId = this.GetChannelUserObjectId(member);
-                    return !dbMembersLookup.ContainsKey(memberObjectId) || dbMembersLookup[memberObjectId];
+                    return dbMembersLookup.ContainsKey(memberObjectId) && dbMembersLookup[memberObjectId].ContainsKey(teamInfo.Id) && dbMembersLookup[memberObjectId][teamInfo.Id];
                 })
                 .ToList();
         }

--- a/Source/Icebreaker/Services/MatchingService.cs
+++ b/Source/Icebreaker/Services/MatchingService.cs
@@ -165,10 +165,18 @@ namespace Icebreaker.Services
             // Fill in person1's info in the card for person2
             var cardForPerson2 = PairUpNotificationAdaptiveCard.GetCard(teamName, teamsPerson2, teamsPerson1, user1.Item2, this.botDisplayName);
 
+            // Feedback card for both users
+            var feedbackCard = FeedbackAdaptiveCard.GetCard();
+
             // Send notifications and return the number that was successful
             var notifyResults = await Task.WhenAll(
                 this.conversationHelper.NotifyUserAsync(this.botAdapter, teamModel.ServiceUrl, teamModel.TeamId, MessageFactory.Attachment(cardForPerson1), teamsPerson1, teamModel.TenantId, cancellationToken),
                 this.conversationHelper.NotifyUserAsync(this.botAdapter, teamModel.ServiceUrl, teamModel.TeamId, MessageFactory.Attachment(cardForPerson2), teamsPerson2, teamModel.TenantId, cancellationToken));
+
+            // Send feedback cards
+            await this.conversationHelper.NotifyUserAsync(this.botAdapter, teamModel.ServiceUrl, teamModel.TeamId, MessageFactory.Attachment(feedbackCard), teamsPerson1, teamModel.TenantId, cancellationToken);
+            await this.conversationHelper.NotifyUserAsync(this.botAdapter, teamModel.ServiceUrl, teamModel.TeamId, MessageFactory.Attachment(feedbackCard), teamsPerson2, teamModel.TenantId, cancellationToken);
+
             return notifyResults.Count(wasNotified => wasNotified);
         }
 

--- a/Source/Icebreaker/Web.config
+++ b/Source/Icebreaker/Web.config
@@ -14,6 +14,7 @@
 		<add key="CosmosCollectionPairs" value="PairsHistory" />
 		<add key="CosmosCollectionTeams" value="TeamsInstalled" />
 		<add key="CosmosCollectionUsers" value="UsersOptInStatus" />
+		<add key="CosmosCollectionFeedback" value="UserFeedback" />
 		<add key="MaxPairUpsPerTeam" value="5000" />
 		<add key="Testing" value="false" />
 		<add key="BotDisplayName" value="Icebreaker" />


### PR DESCRIPTION
This change adds a feedback card that is sent after a match is made. Expanding the feedback card allows the user to enter a 1-5 rating as well as multiline comments. Upon saving, the user is sent a thank you message.

![image](https://user-images.githubusercontent.com/59745105/106658650-8d368a80-656b-11eb-9cdf-f447d0dc471e.png)

This implementation also adds a container to the database to store the rating, comments, and ID of the associated team for each feedback submission.