### PR TITLE
User Profiles

### DIFF
--- a/Source/Icebreaker/Bot/IcebreakerBot.cs
+++ b/Source/Icebreaker/Bot/IcebreakerBot.cs
@@ -593,18 +593,6 @@ namespace Icebreaker.Bot
             var teamName = turnContext.Activity.TeamsGetTeamInfo().Name;
             var welcomeTeamMessageCard = WelcomeTeamAdaptiveCard.GetCard(teamName, botInstaller);
             await this.NotifyTeamAsync(turnContext, MessageFactory.Attachment(welcomeTeamMessageCard), teamId, cancellationToken);
-
-            // welcome users on team
-            var teamInfo = await this.GetInstalledTeam(teamId);
-            var botAdapter = (BotFrameworkAdapter)turnContext.Adapter;
-            var tenantId = turnContext.Activity.GetChannelData<TeamsChannelData>().Tenant.Id;
-            var members = await this.conversationHelper.GetTeamMembers(botAdapter, teamInfo);
-
-            foreach (var member in members)
-            {
-                var userId = this.GetChannelUserObjectId(member);
-                await this.WelcomeUser(turnContext, userId, tenantId, teamId, cancellationToken);
-            }
         }
 
         /// <summary>

--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
@@ -29,35 +29,40 @@ namespace Icebreaker.Helpers.AdaptiveCards
         /// Creates the pairup notification card.
         /// </summary>
         /// <param name="teamName">The team name.</param>
-        /// <param name="sender">The user who will be sending this card.</param>
         /// <param name="recipient">The user who will be receiving this card.</param>
+        /// <param name="sender">The user who will be sending this card.</param>
+        /// <param name="senderProfile">The profile of the sender.</param>
         /// <param name="botDisplayName">The bot display name.</param>
         /// <returns>Pairup notification card</returns>
-        public static Attachment GetCard(string teamName, TeamsChannelAccount sender, TeamsChannelAccount recipient, string botDisplayName)
+        public static Attachment GetCard(string teamName, TeamsChannelAccount recipient, TeamsChannelAccount sender, string senderProfile, string botDisplayName)
         {
             // Guest users may not have their given name specified in AAD, so fall back to the full name if needed
-            var senderGivenName = string.IsNullOrEmpty(sender.GivenName) ? sender.Name : sender.GivenName;
             var recipientGivenName = string.IsNullOrEmpty(recipient.GivenName) ? recipient.Name : recipient.GivenName;
+            var senderGivenName = string.IsNullOrEmpty(sender.GivenName) ? sender.Name : sender.GivenName;
 
             // To start a chat with a guest user, use their external email, not the UPN
-            var recipientUpn = !IsGuestUser(recipient) ? recipient.UserPrincipalName : recipient.Email;
+            var senderUpn = !IsGuestUser(sender) ? sender.UserPrincipalName : sender.Email;
 
-            var meetingTitle = string.Format(Resources.MeetupTitle, senderGivenName, recipientGivenName);
+            var meetingTitle = string.Format(Resources.MeetupTitle, recipientGivenName, senderGivenName);
             var meetingContent = string.Format(Resources.MeetupContent, botDisplayName);
-            var meetingLink = "https://teams.microsoft.com/l/meeting/new?subject=" + Uri.EscapeDataString(meetingTitle) + "&attendees=" + recipientUpn + "&content=" + Uri.EscapeDataString(meetingContent);
+            var meetingLink = "https://teams.microsoft.com/l/meeting/new?subject=" + Uri.EscapeDataString(meetingTitle) + "&attendees=" + senderUpn + "&content=" + Uri.EscapeDataString(meetingContent);
 
             var cardData = new
             {
                 matchUpCardTitleContent = Resources.MatchUpCardTitleContent,
-                matchUpCardMatchedText = string.Format(Resources.MatchUpCardMatchedText, recipient.Name),
-                matchUpCardContentPart1 = string.Format(Resources.MatchUpCardContentPart1, botDisplayName, teamName, recipient.Name),
+                matchUpCardMatchedText = string.Format(Resources.MatchUpCardMatchedText, sender.Name),
+                matchUpCardContentPart1 = string.IsNullOrEmpty(senderProfile) ?
+                    string.Format(Resources.MatchUpCardContentPart1, botDisplayName, teamName, sender.Name) :
+                    string.Format(Resources.MatchUpCardContentPart1b, botDisplayName, teamName, sender.Name, senderProfile),
                 matchUpCardContentPart2 = Resources.MatchUpCardContentPart2,
-                chatWithMatchButtonText = string.Format(Resources.ChatWithMatchButtonText, recipientGivenName),
+                chatWithMatchButtonText = string.Format(Resources.ChatWithMatchButtonText, senderGivenName),
                 chatWithMessageGreeting = Resources.ChatWithMessageGreeting,
                 pauseMatchesButtonText = Resources.PausePairingsButtonText,
+                profilePlaceholderText = Resources.ProfilePlaceholderText,
                 proposeMeetupButtonText = Resources.ProposeMeetupButtonText,
-                personUpn = recipientUpn,
                 viewTeamsButton = Resources.ViewTeamsButtonText,
+                updateProfileButtonText = Resources.UpdateProfileButtonText,
+                personUpn = senderUpn,
                 meetingLink,
             };
 

--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
@@ -61,7 +61,9 @@ namespace Icebreaker.Helpers.AdaptiveCards
                 profilePlaceholderText = Resources.ProfilePlaceholderText,
                 proposeMeetupButtonText = Resources.ProposeMeetupButtonText,
                 viewTeamsButton = Resources.ViewTeamsButtonText,
+                saveButtonText = Resources.SaveButtonText,
                 updateProfileButtonText = Resources.UpdateProfileButtonText,
+                updateProfileAction = Resources.UpdateProfileAction,
                 personUpn = senderUpn,
                 meetingLink,
             };

--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
@@ -100,9 +100,9 @@
           "actions": [
               {
                   "type": "Action.Submit",
-                  "title": "Save",
+                  "title": "${saveButtonText}",
                   "data": {
-                      "ActionType": "update"
+                      "ActionType": "${updateProfileAction}"
                   }
               }
           ]

--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
@@ -77,6 +77,36 @@
           "text": "viewteams"
         }
       }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "${updateProfileButtonText}",
+      "card": {
+          "type": "AdaptiveCard",
+          "body": [
+              {
+                  "type": "Container",
+                  "items": [
+                      {
+                          "type": "Input.Text",
+                          "id": "profile",
+                          "placeholder": "${profilePlaceholderText}",
+                          "maxLength": 1000,
+                          "isMultiline": true
+                      }
+                  ]
+              }
+          ],
+          "actions": [
+              {
+                  "type": "Action.Submit",
+                  "title": "Save",
+                  "data": {
+                      "action": "update"
+                  }
+              }
+          ]
+      }
     }
   ],
   "version": "1.0"

--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.json
@@ -102,7 +102,7 @@
                   "type": "Action.Submit",
                   "title": "Save",
                   "data": {
-                      "action": "update"
+                      "ActionType": "update"
                   }
               }
           ]

--- a/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.cs
@@ -66,8 +66,10 @@ namespace Icebreaker.Helpers.AdaptiveCards
                 tourUrl = $"https://teams.microsoft.com/l/task/{appId}?url={htmlUrl}&height=533px&width=600px&title={tourTitle}",
                 salutationText = Resources.SalutationTitleText,
                 viewTeamsButton = Resources.ViewTeamsButtonText,
+                saveButtonText = Resources.SaveButtonText,
                 setUpProfileButtonText = Resources.SetUpProfileButtonText,
-                tourButtonText = Resources.TakeATourButtonText
+                tourButtonText = Resources.TakeATourButtonText,
+                updateProfileAction = Resources.UpdateProfileAction,
             };
 
             return GetCard(AdaptiveCardTemplate.Value, welcomeData);

--- a/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.cs
@@ -62,10 +62,12 @@ namespace Icebreaker.Helpers.AdaptiveCards
                 team = teamName,
                 welcomeCardImageUrl = $"https://{baseDomain}/Content/welcome-card-image.png",
                 pauseMatchesText = Resources.PausePairingsButtonText,
+                profilePlaceholderText = Resources.ProfilePlaceholderText,
                 tourUrl = $"https://teams.microsoft.com/l/task/{appId}?url={htmlUrl}&height=533px&width=600px&title={tourTitle}",
                 salutationText = Resources.SalutationTitleText,
-                tourButtonText = Resources.TakeATourButtonText,
-                viewTeamsButton = Resources.ViewTeamsButtonText
+                viewTeamsButton = Resources.ViewTeamsButtonText,
+                setUpProfileButtonText = Resources.SetUpProfileButtonText,
+                tourButtonText = Resources.TakeATourButtonText
             };
 
             return GetCard(AdaptiveCardTemplate.Value, welcomeData);

--- a/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
@@ -94,7 +94,7 @@
                   "type": "Action.Submit",
                   "title": "Save",
                   "data": {
-                      "action": "update"
+                      "ActionType": "update"
                   }
               }
           ]

--- a/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
@@ -69,6 +69,36 @@
           "text": "viewteams"
         }
       }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "${setUpProfileButtonText}",
+      "card": {
+          "type": "AdaptiveCard",
+          "body": [
+              {
+                  "type": "Container",
+                  "items": [
+                      {
+                          "type": "Input.Text",
+                          "id": "profile",
+                          "placeholder": "${profilePlaceholderText}",
+                          "maxLength": 1000,
+                          "isMultiline": true
+                      }
+                  ]
+              }
+          ],
+          "actions": [
+              {
+                  "type": "Action.Submit",
+                  "title": "Save",
+                  "data": {
+                      "action": "update"
+                  }
+              }
+          ]
+      }
     }
   ],
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/WelcomeNewMemberAdaptiveCard.json
@@ -92,9 +92,9 @@
           "actions": [
               {
                   "type": "Action.Submit",
-                  "title": "Save",
+                  "title": "${saveButtonText}",
                   "data": {
-                      "ActionType": "update"
+                      "ActionType": "${updateProfileAction}"
                   }
               }
           ]

--- a/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
+++ b/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
@@ -242,15 +242,63 @@ namespace Icebreaker.Helpers
         }
 
         /// <summary>
+        /// Get the stored profiles of given users
+        /// </summary>
+        /// <returns>User's custom profiles</returns>
+        public async Task<Dictionary<string, string>> GetAllUsersProfileAsync()
+        {
+            await this.EnsureInitializedAsync();
+
+            try
+            {
+                var collectionLink = UriFactory.CreateDocumentCollectionUri(this.database.Id, this.usersCollection.Id);
+                var query = this.documentClient.CreateDocumentQuery<UserInfo>(
+                        collectionLink,
+#pragma warning disable SA1118 // Parameter must not span multiple lines
+                        new FeedOptions
+                        {
+                            EnableCrossPartitionQuery = true,
+
+                            // Fetch items in bulk according to DB engine capability
+                            MaxItemCount = -1,
+
+                            // Max partition to query at a time
+                            MaxDegreeOfParallelism = -1
+                        })
+#pragma warning restore SA1118 // Parameter must not span multiple lines
+                    .Select(u => new UserInfo { Id = u.Id, Profile = u.Profile })
+                    .AsDocumentQuery();
+                var usersProfileLookup = new Dictionary<string, string>();
+                while (query.HasMoreResults)
+                {
+                    // Note that ExecuteNextAsync can return many records in each call
+                    var responseBatch = await query.ExecuteNextAsync<UserInfo>();
+                    foreach (var userInfo in responseBatch)
+                    {
+                        usersProfileLookup.Add(userInfo.Id, userInfo.Profile);
+                    }
+                }
+
+                return usersProfileLookup;
+            }
+            catch (Exception ex)
+            {
+                this.telemetryClient.TrackException(ex.InnerException);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Set the user info for the given user
         /// </summary>
         /// <param name="tenantId">Tenant id</param>
         /// <param name="userId">User id</param>
         /// <param name="optedIn">User opt-in status for each team user is in</param>
         /// <param name="serviceUrl">User service URL</param>
+        /// <param name="profile">User profile</param>
         /// <param name="cardToDelete">Activity id of card to be deleted</param>
         /// <returns>Tracking task</returns>
-        public async Task SetUserInfoAsync(string tenantId, string userId, IDictionary<string, bool> optedIn, string serviceUrl, string cardToDelete)
+        public async Task SetUserInfoAsync(string tenantId, string userId, IDictionary<string, bool> optedIn, string serviceUrl, string profile, string cardToDelete)
         {
             await this.EnsureInitializedAsync();
 
@@ -260,6 +308,7 @@ namespace Icebreaker.Helpers
                 UserId = userId,
                 OptedIn = optedIn,
                 ServiceUrl = serviceUrl,
+                Profile = profile,
                 CardToDelete = cardToDelete
             };
             await this.documentClient.UpsertDocumentAsync(this.usersCollection.SelfLink, userInfo);
@@ -282,7 +331,7 @@ namespace Icebreaker.Helpers
             var optedIn = userInfo?.OptedIn ?? new Dictionary<string, bool>();
             optedIn.Add(teamId, true);
 
-            await this.SetUserInfoAsync(tenantId, userId, optedIn, serviceUrl, userInfo?.CardToDelete);
+            await this.SetUserInfoAsync(tenantId, userId, optedIn, serviceUrl, userInfo?.Profile, userInfo?.CardToDelete);
         }
 
         /// <summary>
@@ -300,7 +349,7 @@ namespace Icebreaker.Helpers
             var optedIn = userInfo.OptedIn;
             optedIn.Remove(teamId);
 
-            await this.SetUserInfoAsync(userInfo.TenantId, userId, optedIn, userInfo.ServiceUrl, userInfo.CardToDelete);
+            await this.SetUserInfoAsync(userInfo.TenantId, userId, optedIn, userInfo.ServiceUrl, userInfo.Profile, userInfo.CardToDelete);
         }
 
         /// <summary>

--- a/Source/Icebreaker/Helpers/UserInfo.cs
+++ b/Source/Icebreaker/Helpers/UserInfo.cs
@@ -55,5 +55,11 @@ namespace Icebreaker.Helpers
         /// </summary>
         [JsonProperty("recentPairups")]
         public List<UserInfo> RecentPairUps { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's profile
+        /// </summary>
+        [JsonProperty("profile")]
+        public string Profile { get; set; }
     }
 }

--- a/Source/Icebreaker/Interfaces/IBotDataProvider.cs
+++ b/Source/Icebreaker/Interfaces/IBotDataProvider.cs
@@ -28,6 +28,12 @@ namespace Icebreaker.Interfaces
         Task<Dictionary<string, IDictionary<string, bool>>> GetAllUsersOptInStatusAsync();
 
         /// <summary>
+        /// Get the stored profiles of given users
+        /// </summary>
+        /// <returns>User's custom profiles</returns>
+        Task<Dictionary<string, string>> GetAllUsersProfileAsync();
+
+        /// <summary>
         /// Returns the team that the bot has been installed to
         /// </summary>
         /// <param name="teamId">The team id</param>
@@ -56,9 +62,10 @@ namespace Icebreaker.Interfaces
         /// <param name="userId">User id</param>
         /// <param name="optedIn">User opt-in status for each team user is in</param>
         /// <param name="serviceUrl">User service URL</param>
+        /// <param name="profile">User profile</param>
         /// <param name="cardToDelete">Activity id of card to be deleted</param>
         /// <returns>Tracking task</returns>
-        Task SetUserInfoAsync(string tenantId, string userId, IDictionary<string, bool> optedIn, string serviceUrl, string cardToDelete);
+        Task SetUserInfoAsync(string tenantId, string userId, IDictionary<string, bool> optedIn, string serviceUrl, string profile, string cardToDelete);
 
         /// <summary>
         /// Add team to user's teams

--- a/Source/Icebreaker/Properties/Resources.Designer.cs
+++ b/Source/Icebreaker/Properties/Resources.Designer.cs
@@ -340,6 +340,15 @@ namespace Icebreaker.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to update.
+        /// </summary>
+        internal static string UpdateProfileAction {
+            get {
+                return ResourceManager.GetString("UpdateProfileAction", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Your profile has been updated!
         /// </summary>
         internal static string UpdateProfileConfirmation {

--- a/Source/Icebreaker/Properties/Resources.Designer.cs
+++ b/Source/Icebreaker/Properties/Resources.Designer.cs
@@ -167,6 +167,15 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("MatchUpCardContentPart1", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hi there again, I&apos;m {0} in {1}. A bot that pairs you with a new coworker to meet each week. This week your match is {2}. Here is something they wanted to let you know about them: {3}..
+        /// </summary>
+        internal static string MatchUpCardContentPart1b {
+            get {
+                return ResourceManager.GetString("MatchUpCardContentPart1b", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to If you&apos;ve got the inclination, set something up. See, meeting people *is* easy!.
@@ -248,7 +257,16 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("PausePairingsButtonText", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Share something about yourself with future matches!.
+        /// </summary>
+        internal static string ProfilePlaceholderText {
+            get {
+                return ResourceManager.GetString("ProfilePlaceholderText", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Propose meetup.
         /// </summary>
@@ -275,7 +293,7 @@ namespace Icebreaker.Properties {
                 return ResourceManager.GetString("SalutationTitleText", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Save.
         /// </summary>
@@ -295,11 +313,38 @@ namespace Icebreaker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Set up profile.
+        /// </summary>
+        internal static string SetUpProfileButtonText {
+            get {
+                return ResourceManager.GetString("SetUpProfileButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to I&apos;m sorry, but I can&apos;t process the incoming message. You can take a tour, though, to learn more about my functionality..
         /// </summary>
         internal static string UnrecognizedInput {
             get {
                 return ResourceManager.GetString("UnrecognizedInput", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Update profile.
+        /// </summary>
+        internal static string UpdateProfileButtonText {
+            get {
+                return ResourceManager.GetString("UpdateProfileButtonText", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Your profile has been updated!
+        /// </summary>
+        internal static string UpdateProfileConfirmation {
+            get {
+                return ResourceManager.GetString("UpdateProfileConfirmation", resourceCulture);
             }
         }
         

--- a/Source/Icebreaker/Properties/Resources.resx
+++ b/Source/Icebreaker/Properties/Resources.resx
@@ -165,6 +165,10 @@
     <value>Hi there again, I'm {0} in {1}. A bot that pairs you with a new coworker to meet each week. This week your match is {2}.</value>
     <comment>First part of the match up card main content</comment>
   </data>
+  <data name="MatchUpCardContentPart1b" xml:space="preserve">
+    <value>Hi there again, I'm {0} in {1}. A bot that pairs you with a new coworker to meet each week. This week your match is {2}. Here is something they wanted to let you know about them: {3}</value>
+    <comment>First part of the match up card main content for users that have a profile</comment>
+  </data>
   <data name="MatchUpCardContentPart2" xml:space="preserve">
     <value>If you've got the inclination, set something up. See, meeting people *is* easy!</value>
     <comment>Second part of the match up card main content</comment>
@@ -201,6 +205,10 @@
     <value>Pause all matches</value>
     <comment>Button text to pause pairings</comment>
   </data>
+  <data name="ProfilePlaceholderText" xml:space="preserve">
+    <value>Share something about yourself with future matches!</value>
+    <comment>Placeholder for textbox when updating profile.</comment>
+  </data>
   <data name="ProposeMeetupButtonText" xml:space="preserve">
     <value>Propose meetup</value>
     <comment>Button text to propose the meetup with the match of the user</comment>
@@ -217,6 +225,10 @@
     <value>Save</value>
     <comment>Button to save preferences</comment>
   </data>
+  <data name="SetUpProfileButtonText" xml:space="preserve">
+    <value>Set up Profile</value>
+    <comment>Button text to set up profile</comment>
+  </data>
   <data name="TakeATourButtonText" xml:space="preserve">
     <value>Take a tour</value>
     <comment>The text for the button which launches a tour when clicked</comment>
@@ -232,6 +244,14 @@
   <data name="ViewTeamsText" xml:space="preserve">
     <value>Here are your teams! Select the teams that you would like to pause matches for.</value>
     <comment>Text on card where user can edit team matching preferences</comment>
+  </data>
+  <data name="UpdateProfileButtonText" xml:space="preserve">
+    <value>Update Profile</value>
+    <comment>Button text to update profile</comment>
+  </data>
+  <data name="UpdateProfileConfirmation" xml:space="preserve">
+    <value>Your profile has been updated!</value>
+    <comment>The confirmation reply that is sent when the user updates the profile</comment>
   </data>
   <data name="WelcomeTourTitle" xml:space="preserve">
     <value>Tour</value>

--- a/Source/Icebreaker/Properties/Resources.resx
+++ b/Source/Icebreaker/Properties/Resources.resx
@@ -245,6 +245,10 @@
     <value>Here are your teams! Select the teams that you would like to pause matches for.</value>
     <comment>Text on card where user can edit team matching preferences</comment>
   </data>
+  <data name="UpdateProfileAction" xml:space="preserve">
+    <value>update</value>
+    <comment>Action text for updating profile</comment>
+  </data>
   <data name="UpdateProfileButtonText" xml:space="preserve">
     <value>Update Profile</value>
     <comment>Button text to update profile</comment>


### PR DESCRIPTION
**NOTE**
This replaces #126.

**Description**
This is the implementation for allowing users to set profiles for themselves. In this update, a welcome card is sent to each user individually (regardless of whether they join before or after Icebreaker is added). This welcome card includes a "Set up profile" button which can be used to configure their profile. Once saved, this profile will be shared with future matches in the match card. The match card also includes a "Update profile" button, which can be used to conveniently update their profile for future matches.

**User facing changes**
Users will always receive a personal welcome card from Icebreaker with an option to set up their profile. Match cards include an option to update their profile. Match cards share a user's profile with their match if it exists.

Tests can be configured that cover different lengths of profiles for users (represented as strings), the types of characters supported, etc.