### PR TITLE
Fixing AzureAD module installation not working

### DIFF
--- a/Deployment/deploy.ps1
+++ b/Deployment/deploy.ps1
@@ -515,7 +515,7 @@ function InstallDependencies {
 
                 if (-not (Get-Module -ListAvailable -Name "AzureAD")) {
                     WriteInfo "Installing AzureAD module..."
-                    Install-Module AzureAD -Scope CurrentUser -Force
+                    Install-Module AzureAD -AllowClobber -Scope CurrentUser -Force
                 }
                 
                 if (-not (Get-Module -ListAvailable -Name "WriteAscii")) {


### PR DESCRIPTION
Added -AllowClobber parameter to the AzureAD install command so that it installs the module when missing. Error code without -AllowClobber attached with pull request
![4c63ff99-5ca6-47c7-9f1c-6b5214bbdcc6](https://user-images.githubusercontent.com/10238857/151404675-7d53a184-85ac-4fe2-9f01-107956abdb2f.jpg)

